### PR TITLE
[F] Set up investigations landing page

### DIFF
--- a/components/content-blocks/InvestigationsList/index.js
+++ b/components/content-blocks/InvestigationsList/index.js
@@ -1,0 +1,24 @@
+import PropTypes from "prop-types";
+import Link from "next/link";
+
+export default function InvestigationsListBlock({ investigations }) {
+  return (
+    <ul>
+      {investigations.map(({ investigation }) => {
+        const { title, url } = investigation[0];
+
+        return (
+          <li>
+            <Link href={url}>{title}</Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+InvestigationsListBlock.displayName = "ContentBlock.InvestigationsList";
+
+InvestigationsListBlock.propTypes = {
+  investigations: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/components/content-blocks/index.js
+++ b/components/content-blocks/index.js
@@ -1,3 +1,4 @@
 import Text from "./Text";
+import InvestigationsList from "./InvestigationsList";
 
-export { Text };
+export { Text, InvestigationsList };

--- a/components/factories/ContentBlockFactory.js
+++ b/components/factories/ContentBlockFactory.js
@@ -16,6 +16,7 @@ import {
   TableGroup,
   Video,
   DownloadList,
+  InvestigationsList,
 } from "@/content-blocks";
 
 const blockMap = {
@@ -26,6 +27,7 @@ const blockMap = {
   contactStaff: ContactStaff,
   ctaGrid: GridBlock,
   image: Image,
+  investigationsList: InvestigationsList,
   link: Link,
   linkedAsset: Link,
   news: GridBlock,

--- a/components/templates/Investigations/index.js
+++ b/components/templates/Investigations/index.js
@@ -1,0 +1,55 @@
+import PropTypes from "prop-types";
+import Link from "next/link";
+import Body from "@/global/Body";
+import ContentBlockFactory from "@/factories/ContentBlockFactory";
+import Container from "@/layout/Container";
+
+export default function Investigations({
+  data: {
+    id,
+    pageType,
+    contentBlocks,
+    title,
+    uri,
+    typeHandle,
+    next,
+    prev: prevPage,
+    children,
+  },
+}) {
+  const bodyProps = {
+    title,
+  };
+  const nextPage = children[0] || next;
+
+  return (
+    <Body {...bodyProps}>
+      <Container>
+        <h1>{title}</h1>
+        {[...contentBlocks].map((block) => {
+          if (!block.id || !block.typeHandle) return null;
+          return (
+            <ContentBlockFactory
+              key={block.id}
+              type={block.typeHandle}
+              data={block}
+              pageId={id}
+            />
+          );
+        })}
+        {(nextPage || prevPage) && (
+          <footer>
+            {prevPage && <Link href={prevPage.uri}>Previous</Link>}
+            {nextPage && <Link href={nextPage.uri}>Next</Link>}
+          </footer>
+        )}
+      </Container>
+    </Body>
+  );
+}
+
+Investigations.displayName = "Template.Investigations";
+
+Investigations.propTypes = {
+  data: PropTypes.object,
+};

--- a/lib/api/entries.js
+++ b/lib/api/entries.js
@@ -2,11 +2,12 @@ import useSWR from "swr";
 import { gql } from "graphql-request";
 import { queryAPI } from "@/lib/fetch";
 import { pageFragment } from "@/lib/api/fragments/page";
+import { investigationsPageFragment } from "@/lib/api/fragments/investigations";
 
 export async function getAllEntries() {
   const query = gql`
     {
-      entries(site: "*", section: ["pages", "homepage"]) {
+      entries(site: "*", section: ["pages", "homepage", "investigations"]) {
         uri
       }
     }
@@ -45,6 +46,10 @@ export function useDataList({
   let theOrderBy;
 
   switch (section) {
+    case "investigations":
+      theSection = `"investigations"`;
+      theOrderBy = `"dateCreated desc"`;
+      break;
     case "pages":
       theSection = `"pages"`;
       theOrderBy = `"dateCreated desc"`;
@@ -59,12 +64,14 @@ export function useDataList({
       ? null
       : gql`
       ${pageFragment}
+      ${investigationsPageFragment}
       {
         entries (id: ["not", ${excludeId}], section: ${theSection}, 
           site: "${site}", relatedTo: ${listTypeId}, limit: ${limit}, 
           offset: ${offset}, orderBy: ${theOrderBy}, inReverse: ${inReverse}, 
           search: ${search}) {
           ...pageFragment
+          ...investigationsPageFragment
         }
         total: entryCount(id: ["not", ${excludeId}], section: ${theSection}, 
           site: "${site}", relatedTo: ${listTypeId}, limit: ${limit}, 

--- a/lib/api/entry.js
+++ b/lib/api/entry.js
@@ -2,6 +2,7 @@ import { gql } from "graphql-request";
 import { queryAPI } from "@/lib/fetch";
 import { homepageFragment } from "@/lib/api/fragments/homepage";
 import { pageFragment } from "@/lib/api/fragments/page";
+import { investigationsPageFragment } from "@/api/fragments/investigations";
 import { allPageBlocksFragment } from "@/api/fragments/content-blocks";
 
 export async function getEntryDataByUri(uri, site = "default", previewToken) {
@@ -9,10 +10,12 @@ export async function getEntryDataByUri(uri, site = "default", previewToken) {
     ${homepageFragment}
     ${pageFragment}
     ${allPageBlocksFragment}
+    ${investigationsPageFragment}
       {
         entry (site: "${site}", uri: "${uri}") {
           ...homepageFragment
           ...pageFragment
+          ...investigationsPageFragment
         }
       }
     `;

--- a/lib/api/fragments/content-blocks.js
+++ b/lib/api/fragments/content-blocks.js
@@ -12,6 +12,24 @@ export const textBlockFragment = `
   }
 `;
 
+export const investigationsListBlockFragment = `
+  fragment investigationsListBlock on contentBlocks_NeoField {
+    ... on contentBlocks_investigationsList_BlockType {
+      id
+      typeHandle
+      investigations: children {
+        ... on contentBlocks_investigationItem_BlockType {
+          investigation {
+            url
+            title
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const allPageBlocksFragment = `
+${investigationsListBlockFragment}
 ${textBlockFragment}
 `;

--- a/lib/api/fragments/investigations.js
+++ b/lib/api/fragments/investigations.js
@@ -1,0 +1,27 @@
+export const investigationsPageFragment = `fragment investigationsPageFragment on investigations_investigationPage_Entry {
+  id
+  title
+  contentBlocks {
+    ...textBlock
+    ...investigationsListBlock
+  }
+  language
+  localized {
+    uri
+    language
+  }
+  children {
+    uri
+    title
+  }
+  next {
+    uri
+    title
+  }
+  prev {
+    uri
+    title
+  }
+  typeHandle
+  uri
+}`;

--- a/lib/api/fragments/page.js
+++ b/lib/api/fragments/page.js
@@ -14,6 +14,7 @@ export const pageFragment = `
       pageType
       contentBlocks {
         ...textBlock
+        ...investigationsListBlock
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "rubin-client",
-  "version": "0.1.0",
+  "name": "investigations-client",
+  "version": "2.0.0-alpha",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/lsst-epo/next-template"
+    "url": "https://github.com/lsst-epo/investigations-client"
   },
   "scripts": {
     "dev": "npm-run-all --parallel dev:*",

--- a/pages/[[...uriSegments]].js
+++ b/pages/[[...uriSegments]].js
@@ -9,6 +9,7 @@ import HomePageTemplate from "@/templates/HomePage";
 import { internalLinkWithChildrenShape } from "@/shapes/link";
 import siteInfoShape from "@/shapes/siteInfo";
 import { updateI18n } from "@/lib/i18n";
+import InvestigationsTemplate from "@/components/templates/Investigations";
 
 const CRAFT_HOMEPAGE_URI = "__home__";
 
@@ -17,6 +18,7 @@ export default function Page({ section, globalData, ...entryProps }) {
 
   const sectionMap = {
     homepage: HomePageTemplate,
+    investigations: InvestigationsTemplate,
   };
 
   const Template = sectionMap[section] || PageTemplate;
@@ -94,8 +96,6 @@ export async function getStaticProps({ params: { uriSegments }, previewData }) {
     revalidate: 30,
   };
 }
-
-Page.displayName = "Entry.Page";
 
 Page.propTypes = {
   data: PropTypes.object,


### PR DESCRIPTION
## What this change does ##

Sets up an investigations landing page for listing the currently available investigations along with a basic investigation page and navigation

## Notes for reviewers ##

Include an indication of how detailed a review you want on a 1-10 scale.
- 5

## Testing ##

Start development server with EPO-6250 API branch running. Go to the /investigations page to view the currently listed investigations and navigate into them for some sample content. 