### PR TITLE
[C] add page navigation to investigations

### DIFF
--- a/components/global/PageNavigation/index.js
+++ b/components/global/PageNavigation/index.js
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types";
+import Link from "next/link";
+
+export default function PageNavigation({ prev, next, level }) {
+  const isIntroduction = level === 1;
+  const isLastPage = next && next.level < level;
+
+  return (
+    <div>
+      {prev && !isIntroduction && (
+        <Link href={prev.uri}>{`← ${prev.title}`}</Link>
+      )}
+      {prev && next && !isIntroduction && !isLastPage && ` | `}
+      {next && !isLastPage && <Link href={next.uri}>{`${next.title} →`}</Link>}
+    </div>
+  );
+}
+
+PageNavigation.displayName = "Global.PageNavigation";
+
+PageNavigation.propTypes = {
+  prev: PropTypes.object,
+  next: PropTypes.object,
+  level: PropTypes.number,
+};

--- a/components/templates/Investigations/index.js
+++ b/components/templates/Investigations/index.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Body from "@/global/Body";
 import ContentBlockFactory from "@/factories/ContentBlockFactory";
 import Container from "@/layout/Container";
+import PageNavigation from "@/components/global/PageNavigation";
 
 export default function Investigations({
   data: {
@@ -13,14 +14,13 @@ export default function Investigations({
     uri,
     typeHandle,
     next,
-    prev: prevPage,
-    children,
+    prev,
+    level,
   },
 }) {
   const bodyProps = {
     title,
   };
-  const nextPage = children[0] || next;
 
   return (
     <Body {...bodyProps}>
@@ -37,12 +37,7 @@ export default function Investigations({
             />
           );
         })}
-        {(nextPage || prevPage) && (
-          <footer>
-            {prevPage && <Link href={prevPage.uri}>Previous</Link>}
-            {nextPage && <Link href={nextPage.uri}>Next</Link>}
-          </footer>
-        )}
+        <PageNavigation {...{ prev, next, level }}></PageNavigation>
       </Container>
     </Body>
   );

--- a/lib/api/fragments/investigations.js
+++ b/lib/api/fragments/investigations.js
@@ -10,18 +10,17 @@ export const investigationsPageFragment = `fragment investigationsPageFragment o
     uri
     language
   }
-  children {
+  next(section: "investigations") {
     uri
+    level
     title
   }
-  next {
+  prev(section: "investigations") {
     uri
-    title
-  }
-  prev {
-    uri
+    level
     title
   }
   typeHandle
   uri
+  level
 }`;


### PR DESCRIPTION
For git: "Resolves EPO-6376"
For JIRA: "EPO-6376 #IN-REVIEW #comment Add page navigation to investigations"

JIRA: https://jira.lsstcorp.org/browse/EPO-6376

## What this change does ##

Update the GraphQL entry query to retrieve the next/previous entry and display a page navigation for investigation pages

## Notes for reviewers ##

Review change on local client build

Include an indication of how detailed a review you want on a 1-10 scale.
- 2

## Testing ##

Go to localhost:3000/investigations and select an investigation, begin navigating through the investigation, upon reaching the last page of the investigation there should not be a link to any further pages.


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
