### PR TITLE
[B] Fix missing translations in client components

### DIFF
--- a/lib/i18n/client.ts
+++ b/lib/i18n/client.ts
@@ -1,17 +1,41 @@
 "use client";
 
 import i18next from "i18next";
+import resourcesToBackend from "i18next-resources-to-backend";
 import {
   initReactI18next,
   useTranslation as useTranslationOrg,
 } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
-import { getOptions } from "./settings";
+import { fallbackLng, defaultNS, getOptions } from "./settings";
 
 // on client side the normal singleton is ok
 i18next
   .use(initReactI18next)
   .use(LanguageDetector)
+  .use(
+    resourcesToBackend((language: string, namespace: string, callback) => {
+      if (namespace === "epo-react-lib") {
+        import(
+          `@rubin-epo/epo-react-lib/localeStrings/${language}/${namespace}.json`
+        )
+          .then(({ default: resources }) => {
+            callback(null, resources);
+          })
+          .catch((error) => {
+            callback(error, null);
+          });
+      } else {
+        import(`../../public/localeStrings/${language}/${namespace}.json`)
+          .then(({ default: resources }) => {
+            callback(null, resources);
+          })
+          .catch((error) => {
+            callback(error, null);
+          });
+      }
+    })
+  )
   .init({
     ...getOptions(),
     lng: undefined, // let detect the language on client side
@@ -20,7 +44,11 @@ i18next
     },
   });
 
-export function useTranslation(lng: string, ns: string, options: any) {
+export function useTranslation(
+  lng: string = fallbackLng,
+  ns: string = defaultNS,
+  options?: any
+) {
   if (i18next.resolvedLanguage !== lng) i18next.changeLanguage(lng);
   return useTranslationOrg(ns, options);
 }


### PR DESCRIPTION
I also added default values for the `lng` and `ns` params `useTranslation()` so I didn't have to define them every time, but I'm happy to remove that if you're not a fan.