### PR TITLE
[F] Implement bulk save mutation

### DIFF
--- a/app/[locale]/[investigation]/[...uriSegments]/page.tsx
+++ b/app/[locale]/[investigation]/[...uriSegments]/page.tsx
@@ -92,7 +92,13 @@ const UriSegments: (props: UriSegmentsProps) => Promise<JSX.Element> = async ({
 
   const user = getUserFromJwt(craftToken);
 
-  return <Template {...{ site, user, locale }} data={entry} />;
+  return (
+    <Template
+      {...{ site, user, locale }}
+      data={entry}
+      userStatus={craftUserStatus}
+    />
+  );
 };
 
 export default UriSegments;

--- a/components/answers/SaveForm/SaveForm.tsx
+++ b/components/answers/SaveForm/SaveForm.tsx
@@ -11,15 +11,22 @@ import { getUserFromJwt } from "@/components/auth/serverHelpers";
 export default function SaveForm({
   investigationId,
   user,
+  userStatus,
 }: {
   investigationId: InvestigationId;
   user?: ReturnType<typeof getUserFromJwt>;
+  userStatus?: string;
 }) {
   const { t } = useTranslation();
 
   const [status, setStatus] = useState<
-    "emptyError" | "refreshError" | "mutationError" | "success" | null
-  >(null);
+    | "emptyError"
+    | "refreshError"
+    | "mutationError"
+    | "statusError"
+    | "success"
+    | null
+  >(userStatus === "pending" ? "statusError" : null);
 
   if (!investigationId || !user) return null;
 
@@ -48,6 +55,8 @@ export default function SaveForm({
           );
           if (result === "refreshError") {
             setStatus("refreshError");
+          } else if (result === "statusError") {
+            setStatus("statusError");
           } else {
             setStatus("success");
           }
@@ -57,7 +66,10 @@ export default function SaveForm({
       }}
       aria-label={t("answers.save_form.label") ?? undefined}
     >
-      <Submit disabled={status !== null} icon="FloppyDisk">
+      <Submit
+        disabled={status !== null}
+        icon="FloppyDisk"
+      >
         {(pending) =>
           t(
             pending
@@ -78,6 +90,9 @@ export default function SaveForm({
         )}
         {status === "mutationError" && (
           <p>{t("answers.save_form.mutation_error_message")}</p>
+        )}
+        {status === "statusError" && (
+          <p>{t("answers.save_form.status_error_message")}</p>
         )}
       </output>
     </form>

--- a/components/educator-schema/saveAnswersAction.ts
+++ b/components/educator-schema/saveAnswersAction.ts
@@ -25,10 +25,14 @@ export default async function saveAnswers(
   investigationId: NonNullable<InvestigationId>,
   answers: Answers
 ) {
-  const { craftUserId, craftToken } = await getAuthCookies();
+  const { craftUserId, craftToken, craftUserStatus } = await getAuthCookies();
 
   if (!craftUserId || !craftToken) {
     return "refreshError";
+  }
+
+  if (craftUserStatus === "pending") {
+    return "statusError";
   }
 
   const answerSet = Object.values(answers);

--- a/components/student-schema/saveAnswersAction.ts
+++ b/components/student-schema/saveAnswersAction.ts
@@ -25,10 +25,14 @@ export default async function saveAnswers(
   investigationId: NonNullable<InvestigationId>,
   answers: Answers
 ) {
-  const { craftUserId, craftToken } = await getAuthCookies();
+  const { craftUserId, craftToken, craftUserStatus } = await getAuthCookies();
 
   if (!craftUserId || !craftToken) {
     return "refreshError";
+  }
+
+  if (craftUserStatus === "pending") {
+    return "statusError";
   }
 
   const answerSet = Object.values(answers);

--- a/components/templates/InvestigationChildPage/index.tsx
+++ b/components/templates/InvestigationChildPage/index.tsx
@@ -128,6 +128,7 @@ const InvestigationChildPage: FunctionComponent<{
   data: FragmentType<typeof Fragment>;
   site: string;
   user?: ReturnType<typeof getUserFromJwt>;
+  userStatus?: string;
   children?: React.ReactNode;
 }> = (props) => {
   const data = useFragment(Fragment, props.data);
@@ -145,7 +146,11 @@ const InvestigationChildPage: FunctionComponent<{
           )
       )}
       {data.hasSavePoint && props.user && (
-        <SaveForm investigationId={data.parent?.id} user={props.user} />
+        <SaveForm
+          investigationId={data.parent?.id}
+          user={props.user}
+          userStatus={props.userStatus}
+        />
       )}
     </Styled.ContentBlocks>
   );

--- a/contexts/StoredAnswersContext.tsx
+++ b/contexts/StoredAnswersContext.tsx
@@ -64,7 +64,7 @@ function StoredAnswersProvider(props: {
       const newAnswers = Object.assign({}, prevAnswers, {
         [questionId]: {
           data,
-          questionId: Number(questionId),
+          questionId,
           ...(answerId && { id: answerId }),
         },
       });

--- a/gql/educator-schema/gql.ts
+++ b/gql/educator-schema/gql.ts
@@ -14,8 +14,7 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
  */
 const documents = {
     "\n  query StoredAnswers($userId: ID, $investigationId: ID) {\n    answers(userId: $userId, investigationId: $investigationId) {\n      data\n      questionId\n      id\n    }\n  }\n": types.StoredAnswersDocument,
-    "\n  mutation CreateAnswer(\n    $userId: Int!\n    $questionId: Int!\n    $investigationId: Int!\n    $data: String\n  ) {\n    createAnswer(\n      userId: $userId\n      questionId: $questionId\n      investigationId: $investigationId\n      data: $data\n    ) {\n      questionId\n    }\n  }\n": types.CreateAnswerDocument,
-    "\n  mutation SaveAnswer($answerId: Int!, $data: String) {\n    saveAnswer(id: $answerId, data: $data) {\n      questionId\n    }\n  }\n": types.SaveAnswerDocument,
+    "\n  mutation SaveAnswersFromSet(\n    $userId: ID!\n    $investigationId: ID!\n    $answerSet: [AnswerInput]\n  ) {\n    saveAnswersFromSet(\n      userId: $userId\n      investigationId: $investigationId\n      answerSet: $answerSet\n    ) {\n      id\n    }\n  }\n": types.SaveAnswersFromSetDocument,
 };
 
 /**
@@ -39,11 +38,7 @@ export function graphql(source: "\n  query StoredAnswers($userId: ID, $investiga
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  mutation CreateAnswer(\n    $userId: Int!\n    $questionId: Int!\n    $investigationId: Int!\n    $data: String\n  ) {\n    createAnswer(\n      userId: $userId\n      questionId: $questionId\n      investigationId: $investigationId\n      data: $data\n    ) {\n      questionId\n    }\n  }\n"): (typeof documents)["\n  mutation CreateAnswer(\n    $userId: Int!\n    $questionId: Int!\n    $investigationId: Int!\n    $data: String\n  ) {\n    createAnswer(\n      userId: $userId\n      questionId: $questionId\n      investigationId: $investigationId\n      data: $data\n    ) {\n      questionId\n    }\n  }\n"];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n  mutation SaveAnswer($answerId: Int!, $data: String) {\n    saveAnswer(id: $answerId, data: $data) {\n      questionId\n    }\n  }\n"): (typeof documents)["\n  mutation SaveAnswer($answerId: Int!, $data: String) {\n    saveAnswer(id: $answerId, data: $data) {\n      questionId\n    }\n  }\n"];
+export function graphql(source: "\n  mutation SaveAnswersFromSet(\n    $userId: ID!\n    $investigationId: ID!\n    $answerSet: [AnswerInput]\n  ) {\n    saveAnswersFromSet(\n      userId: $userId\n      investigationId: $investigationId\n      answerSet: $answerSet\n    ) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation SaveAnswersFromSet(\n    $userId: ID!\n    $investigationId: ID!\n    $answerSet: [AnswerInput]\n  ) {\n    saveAnswersFromSet(\n      userId: $userId\n      investigationId: $investigationId\n      answerSet: $answerSet\n    ) {\n      id\n    }\n  }\n"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/gql/educator-schema/graphql.ts
+++ b/gql/educator-schema/graphql.ts
@@ -173,6 +173,15 @@ export type AddressInterface_CountArgs = {
   field: Scalars['String']['input'];
 };
 
+export type AnswerInput = {
+  /** The data submitted by the user. */
+  data?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the Answer element, if it exists. */
+  id?: InputMaybe<Scalars['ID']['input']>;
+  /** The ID of the associated Question entry. */
+  questionId?: InputMaybe<Scalars['ID']['input']>;
+};
+
 /** The interface implemented by all answers. */
 export type AnswerInterface = {
   /** Return a number of related elements for a field. */
@@ -190,11 +199,11 @@ export type AnswerInterface = {
   /** The ID of the entity */
   id?: Maybe<Scalars['ID']['output']>;
   /** ID of the Investigation parent */
-  investigationId?: Maybe<Scalars['Int']['output']>;
+  investigationId?: Maybe<Scalars['ID']['output']>;
   /** The language of the site element is associated with. */
   language?: Maybe<Scalars['String']['output']>;
   /** ID of the question being answered */
-  questionId?: Maybe<Scalars['Int']['output']>;
+  questionId?: Maybe<Scalars['ID']['output']>;
   /** The element’s search score, if the `search` parameter was used when querying for the element. */
   searchScore?: Maybe<Scalars['Int']['output']>;
   /** The handle of the site the element is associated with. */
@@ -216,7 +225,7 @@ export type AnswerInterface = {
   /** The element’s URI. */
   uri?: Maybe<Scalars['String']['output']>;
   /** ID of the user answering the question */
-  userId?: Maybe<Scalars['Int']['output']>;
+  userId?: Maybe<Scalars['ID']['output']>;
 };
 
 
@@ -2147,6 +2156,8 @@ export type Mutation = {
   resendActivation: Scalars['String']['output'];
   /** Saves an existing answer */
   saveAnswer?: Maybe<AnswerInterface>;
+  /** Saves a set of answers */
+  saveAnswersFromSet?: Maybe<Array<Maybe<AnswerInterface>>>;
   /** Sets password for unauthenticated user. Requires `code` and `id` from Craft reset password email. Returns success message. */
   setPassword: Scalars['String']['output'];
   /** Updates password for authenticated user. Requires JWT and current password. Returns success message. */
@@ -2170,9 +2181,9 @@ export type MutationAuthenticateArgs = {
 
 export type MutationCreateAnswerArgs = {
   data?: InputMaybe<Scalars['String']['input']>;
-  investigationId: Scalars['Int']['input'];
-  questionId: Scalars['Int']['input'];
-  userId: Scalars['Int']['input'];
+  investigationId: Scalars['ID']['input'];
+  questionId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
 };
 
 
@@ -2252,7 +2263,14 @@ export type MutationResendActivationArgs = {
 
 export type MutationSaveAnswerArgs = {
   data?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['Int']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationSaveAnswersFromSetArgs = {
+  answerSet?: InputMaybe<Array<InputMaybe<AnswerInput>>>;
+  investigationId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
 };
 
 
@@ -9584,25 +9602,15 @@ export type StoredAnswersQueryVariables = Exact<{
 
 export type StoredAnswersQuery = { __typename?: 'Query', answers?: Array<never | null> | null };
 
-export type CreateAnswerMutationVariables = Exact<{
-  userId: Scalars['Int']['input'];
-  questionId: Scalars['Int']['input'];
-  investigationId: Scalars['Int']['input'];
-  data?: InputMaybe<Scalars['String']['input']>;
+export type SaveAnswersFromSetMutationVariables = Exact<{
+  userId: Scalars['ID']['input'];
+  investigationId: Scalars['ID']['input'];
+  answerSet?: InputMaybe<Array<InputMaybe<AnswerInput>> | InputMaybe<AnswerInput>>;
 }>;
 
 
-export type CreateAnswerMutation = { __typename?: 'Mutation', createAnswer?: never | null };
-
-export type SaveAnswerMutationVariables = Exact<{
-  answerId: Scalars['Int']['input'];
-  data?: InputMaybe<Scalars['String']['input']>;
-}>;
-
-
-export type SaveAnswerMutation = { __typename?: 'Mutation', saveAnswer?: never | null };
+export type SaveAnswersFromSetMutation = { __typename?: 'Mutation', saveAnswersFromSet?: Array<never | null> | null };
 
 
 export const StoredAnswersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"StoredAnswers"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"answers"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}},{"kind":"Argument","name":{"kind":"Name","value":"investigationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"data"}},{"kind":"Field","name":{"kind":"Name","value":"questionId"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<StoredAnswersQuery, StoredAnswersQueryVariables>;
-export const CreateAnswerDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateAnswer"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"questionId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"data"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createAnswer"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}},{"kind":"Argument","name":{"kind":"Name","value":"questionId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"questionId"}}},{"kind":"Argument","name":{"kind":"Name","value":"investigationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}}},{"kind":"Argument","name":{"kind":"Name","value":"data"},"value":{"kind":"Variable","name":{"kind":"Name","value":"data"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"questionId"}}]}}]}}]} as unknown as DocumentNode<CreateAnswerMutation, CreateAnswerMutationVariables>;
-export const SaveAnswerDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SaveAnswer"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"answerId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"data"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"saveAnswer"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"answerId"}}},{"kind":"Argument","name":{"kind":"Name","value":"data"},"value":{"kind":"Variable","name":{"kind":"Name","value":"data"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"questionId"}}]}}]}}]} as unknown as DocumentNode<SaveAnswerMutation, SaveAnswerMutationVariables>;
+export const SaveAnswersFromSetDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SaveAnswersFromSet"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"answerSet"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AnswerInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"saveAnswersFromSet"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}},{"kind":"Argument","name":{"kind":"Name","value":"investigationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}}},{"kind":"Argument","name":{"kind":"Name","value":"answerSet"},"value":{"kind":"Variable","name":{"kind":"Name","value":"answerSet"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SaveAnswersFromSetMutation, SaveAnswersFromSetMutationVariables>;

--- a/gql/student-schema/gql.ts
+++ b/gql/student-schema/gql.ts
@@ -14,8 +14,7 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
  */
 const documents = {
     "\n  query StoredAnswers($userId: ID, $investigationId: ID) {\n    answers(userId: $userId, investigationId: $investigationId) {\n      data\n      questionId\n      id\n    }\n  }\n": types.StoredAnswersDocument,
-    "\n  mutation CreateAnswer(\n    $userId: Int!\n    $questionId: Int!\n    $investigationId: Int!\n    $data: String\n  ) {\n    createAnswer(\n      userId: $userId\n      questionId: $questionId\n      investigationId: $investigationId\n      data: $data\n    ) {\n      questionId\n    }\n  }\n": types.CreateAnswerDocument,
-    "\n  mutation SaveAnswer($answerId: Int!, $data: String) {\n    saveAnswer(id: $answerId, data: $data) {\n      questionId\n    }\n  }\n": types.SaveAnswerDocument,
+    "\n  mutation SaveAnswersFromSet(\n    $userId: ID!\n    $investigationId: ID!\n    $answerSet: [AnswerInput]\n  ) {\n    saveAnswersFromSet(\n      userId: $userId\n      investigationId: $investigationId\n      answerSet: $answerSet\n    ) {\n      id\n    }\n  }\n": types.SaveAnswersFromSetDocument,
 };
 
 /**
@@ -39,11 +38,7 @@ export function graphql(source: "\n  query StoredAnswers($userId: ID, $investiga
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  mutation CreateAnswer(\n    $userId: Int!\n    $questionId: Int!\n    $investigationId: Int!\n    $data: String\n  ) {\n    createAnswer(\n      userId: $userId\n      questionId: $questionId\n      investigationId: $investigationId\n      data: $data\n    ) {\n      questionId\n    }\n  }\n"): (typeof documents)["\n  mutation CreateAnswer(\n    $userId: Int!\n    $questionId: Int!\n    $investigationId: Int!\n    $data: String\n  ) {\n    createAnswer(\n      userId: $userId\n      questionId: $questionId\n      investigationId: $investigationId\n      data: $data\n    ) {\n      questionId\n    }\n  }\n"];
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(source: "\n  mutation SaveAnswer($answerId: Int!, $data: String) {\n    saveAnswer(id: $answerId, data: $data) {\n      questionId\n    }\n  }\n"): (typeof documents)["\n  mutation SaveAnswer($answerId: Int!, $data: String) {\n    saveAnswer(id: $answerId, data: $data) {\n      questionId\n    }\n  }\n"];
+export function graphql(source: "\n  mutation SaveAnswersFromSet(\n    $userId: ID!\n    $investigationId: ID!\n    $answerSet: [AnswerInput]\n  ) {\n    saveAnswersFromSet(\n      userId: $userId\n      investigationId: $investigationId\n      answerSet: $answerSet\n    ) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation SaveAnswersFromSet(\n    $userId: ID!\n    $investigationId: ID!\n    $answerSet: [AnswerInput]\n  ) {\n    saveAnswersFromSet(\n      userId: $userId\n      investigationId: $investigationId\n      answerSet: $answerSet\n    ) {\n      id\n    }\n  }\n"];
 
 export function graphql(source: string) {
   return (documents as any)[source] ?? {};

--- a/gql/student-schema/graphql.ts
+++ b/gql/student-schema/graphql.ts
@@ -173,6 +173,15 @@ export type AddressInterface_CountArgs = {
   field: Scalars['String']['input'];
 };
 
+export type AnswerInput = {
+  /** The data submitted by the user. */
+  data?: InputMaybe<Scalars['String']['input']>;
+  /** The ID of the Answer element, if it exists. */
+  id?: InputMaybe<Scalars['ID']['input']>;
+  /** The ID of the associated Question entry. */
+  questionId?: InputMaybe<Scalars['ID']['input']>;
+};
+
 /** The interface implemented by all answers. */
 export type AnswerInterface = {
   /** Return a number of related elements for a field. */
@@ -190,11 +199,11 @@ export type AnswerInterface = {
   /** The ID of the entity */
   id?: Maybe<Scalars['ID']['output']>;
   /** ID of the Investigation parent */
-  investigationId?: Maybe<Scalars['Int']['output']>;
+  investigationId?: Maybe<Scalars['ID']['output']>;
   /** The language of the site element is associated with. */
   language?: Maybe<Scalars['String']['output']>;
   /** ID of the question being answered */
-  questionId?: Maybe<Scalars['Int']['output']>;
+  questionId?: Maybe<Scalars['ID']['output']>;
   /** The element’s search score, if the `search` parameter was used when querying for the element. */
   searchScore?: Maybe<Scalars['Int']['output']>;
   /** The handle of the site the element is associated with. */
@@ -216,7 +225,7 @@ export type AnswerInterface = {
   /** The element’s URI. */
   uri?: Maybe<Scalars['String']['output']>;
   /** ID of the user answering the question */
-  userId?: Maybe<Scalars['Int']['output']>;
+  userId?: Maybe<Scalars['ID']['output']>;
 };
 
 
@@ -2147,6 +2156,8 @@ export type Mutation = {
   resendActivation: Scalars['String']['output'];
   /** Saves an existing answer */
   saveAnswer?: Maybe<AnswerInterface>;
+  /** Saves a set of answers */
+  saveAnswersFromSet?: Maybe<Array<Maybe<AnswerInterface>>>;
   /** Sets password for unauthenticated user. Requires `code` and `id` from Craft reset password email. Returns success message. */
   setPassword: Scalars['String']['output'];
   /** Updates password for authenticated user. Requires JWT and current password. Returns success message. */
@@ -2170,9 +2181,9 @@ export type MutationAuthenticateArgs = {
 
 export type MutationCreateAnswerArgs = {
   data?: InputMaybe<Scalars['String']['input']>;
-  investigationId: Scalars['Int']['input'];
-  questionId: Scalars['Int']['input'];
-  userId: Scalars['Int']['input'];
+  investigationId: Scalars['ID']['input'];
+  questionId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
 };
 
 
@@ -2252,7 +2263,14 @@ export type MutationResendActivationArgs = {
 
 export type MutationSaveAnswerArgs = {
   data?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['Int']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationSaveAnswersFromSetArgs = {
+  answerSet?: InputMaybe<Array<InputMaybe<AnswerInput>>>;
+  investigationId: Scalars['ID']['input'];
+  userId: Scalars['ID']['input'];
 };
 
 
@@ -9584,25 +9602,15 @@ export type StoredAnswersQueryVariables = Exact<{
 
 export type StoredAnswersQuery = { __typename?: 'Query', answers?: Array<never | null> | null };
 
-export type CreateAnswerMutationVariables = Exact<{
-  userId: Scalars['Int']['input'];
-  questionId: Scalars['Int']['input'];
-  investigationId: Scalars['Int']['input'];
-  data?: InputMaybe<Scalars['String']['input']>;
+export type SaveAnswersFromSetMutationVariables = Exact<{
+  userId: Scalars['ID']['input'];
+  investigationId: Scalars['ID']['input'];
+  answerSet?: InputMaybe<Array<InputMaybe<AnswerInput>> | InputMaybe<AnswerInput>>;
 }>;
 
 
-export type CreateAnswerMutation = { __typename?: 'Mutation', createAnswer?: never | null };
-
-export type SaveAnswerMutationVariables = Exact<{
-  answerId: Scalars['Int']['input'];
-  data?: InputMaybe<Scalars['String']['input']>;
-}>;
-
-
-export type SaveAnswerMutation = { __typename?: 'Mutation', saveAnswer?: never | null };
+export type SaveAnswersFromSetMutation = { __typename?: 'Mutation', saveAnswersFromSet?: Array<never | null> | null };
 
 
 export const StoredAnswersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"StoredAnswers"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"answers"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}},{"kind":"Argument","name":{"kind":"Name","value":"investigationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"data"}},{"kind":"Field","name":{"kind":"Name","value":"questionId"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<StoredAnswersQuery, StoredAnswersQueryVariables>;
-export const CreateAnswerDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateAnswer"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"questionId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"data"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createAnswer"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}},{"kind":"Argument","name":{"kind":"Name","value":"questionId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"questionId"}}},{"kind":"Argument","name":{"kind":"Name","value":"investigationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}}},{"kind":"Argument","name":{"kind":"Name","value":"data"},"value":{"kind":"Variable","name":{"kind":"Name","value":"data"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"questionId"}}]}}]}}]} as unknown as DocumentNode<CreateAnswerMutation, CreateAnswerMutationVariables>;
-export const SaveAnswerDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SaveAnswer"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"answerId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"data"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"saveAnswer"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"answerId"}}},{"kind":"Argument","name":{"kind":"Name","value":"data"},"value":{"kind":"Variable","name":{"kind":"Name","value":"data"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"questionId"}}]}}]}}]} as unknown as DocumentNode<SaveAnswerMutation, SaveAnswerMutationVariables>;
+export const SaveAnswersFromSetDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SaveAnswersFromSet"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"answerSet"}},"type":{"kind":"ListType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AnswerInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"saveAnswersFromSet"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"userId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}},{"kind":"Argument","name":{"kind":"Name","value":"investigationId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"investigationId"}}},{"kind":"Argument","name":{"kind":"Name","value":"answerSet"},"value":{"kind":"Variable","name":{"kind":"Name","value":"answerSet"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SaveAnswersFromSetMutation, SaveAnswersFromSetMutationVariables>;

--- a/public/localeStrings/en/translation.json
+++ b/public/localeStrings/en/translation.json
@@ -244,7 +244,8 @@
       "success_message": "Answers saved!",
       "empty_error_message": "No new answers to save.",
       "refresh_error_message": "Your session has expired. Please log back in and try again.",
-      "mutation_error_message": "There was an error saving your answers to your account."
+      "mutation_error_message": "There was an error saving your answers to your account.",
+      "status_error_message": "Activate your account to begin saving. Check your inbox for an activation email."
     }
   },
   "review": {

--- a/types/answers.d.ts
+++ b/types/answers.d.ts
@@ -1,9 +1,9 @@
-import { AnswerInterface } from "@/gql/student-schema/graphql";
+import { AnswerInput } from "@/gql/student-schema/graphql";
 
 type QuestionId = string;
 
 export type InvestigationId = string | null | undefined;
 
 export type Answers = {
-  [key: QuestionId]: Pick<AnswerInterface, "data" | "questionId" | "id">;
+  [key: QuestionId]: AnswerInput;
 };


### PR DESCRIPTION
Resolves #52 
Resolves #53 

*Note: this PR should be merged only after [the corresponding PR in the API repo](https://github.com/lsst-epo/investigations-api/pull/33/files) is merged.*

## What this change does ##

This PR updates the client to work with the new resolver in the API so that an entire answer set can be submitted for an investigation in one mutation.

It also adds logic to handle user accounts in a pending state. In such cases, the Save Your Work button is be disabled and a message is shown to users to activate their account. The mutation will also not run, should someone still find a way to submit the form.

## Notes for reviewers ##

Include an indication of how detailed a review you want on a 1-10 scale.
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [X] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does