### PR TITLE
[B] Improve answer storage logic

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -52,7 +52,6 @@ const HomePage: (props: HomePageProps) => Promise<JSX.Element> = async ({
         <>
           <p>User: {JSON.stringify(user)}</p>
           {craftUserStatus && <p>Status: {craftUserStatus}</p>}
-          {/* @ts-expect-error Server Component */}
           <SignOut redirectTo={"/"} />
         </>
       )}

--- a/components/auth/buttons/SignOut/SignOut.tsx
+++ b/components/auth/buttons/SignOut/SignOut.tsx
@@ -1,20 +1,18 @@
-import { redirect } from "next/navigation";
+"use client";
+
 import Button from "@rubin-epo/epo-react-lib/Button";
-import { deleteAuthCookies } from "@/components/auth/serverHelpers";
+import { signOut } from "./actions";
 
-export default async function SignOut({ redirectTo }: { redirectTo: string }) {
-  async function signOut() {
-    "use server";
-
-    deleteAuthCookies();
-    redirect(redirectTo);
-  }
+export default function SignOut({ redirectTo }: { redirectTo: string }) {
+  const signOutWithRedirect = signOut.bind(null, redirectTo);
 
   return (
     <form
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      action={signOut}
+      action={signOutWithRedirect}
+      // clear stored answers from browser storage
+      onSubmit={() => localStorage.clear()}
     >
       <Button className="sign-out">Sign out</Button>
     </form>


### PR DESCRIPTION
## What this change does ##

This PR makes two changes:

1. On sign out, the user's local storage is cleared. Unfortunately there's not a more granular solution to deleting answers, since we can't really know all the investigations that a user has stored responses for, which we'd need to reference particular keys in storage. But as long as local storage isn't being used for other purposes in the application (and that couldn't also be cleared on sign-out), I think this solution is OK.
2. The StoredAnswersProvider is also updated to initially give priority to answers stored in the DB. There's a bit of logic to only do this the first time the context is loaded. Otherwise DB answers would continue to overwrite local storage on subsequent updates. I don't _love_ the solution, because if someone reloads the page their answers revert to DB values, but I couldn't find a viable alternative. `getServerSnapshot()` provides the initial value and would be a nice place to merge answer sets, but it doesn't have access to local storage. I wondered whether we could use cookies instead of local storage, but the byte limit on cookie values would likely be too low. If you have any other ideas, I'm all ears!