### PR TITLE
[B] parse answer data from JSON

### DIFF
--- a/contexts/StoredAnswersContext.tsx
+++ b/contexts/StoredAnswersContext.tsx
@@ -44,11 +44,17 @@ function StoredAnswersProvider(props: {
   const getServerSnapshot = useCallback(() => {
     const answerSet = Array.isArray(props.answers)
       ? (Object.fromEntries(
-          props.answers.map((answer) => [answer?.questionId, answer])
+          props.answers.map((answer) => {
+            return [
+              answer?.questionId,
+              { ...answer, data: JSON.parse(answer?.data || "") },
+            ];
+          })
         ) as Answers)
       : {};
+
     return JSON.stringify(answerSet);
-  }, [JSON.stringify(props.answers)]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [props.answers]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const getSnapshot = useCallback(() => {
     const browserAnswers = JSON.parse(


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-8686

## What this change does ##

Data from server answers was being passed along as JSON strings and getting re-stringified, further nesting it in double quotes and escaped double quotes. This indicated a mismatch between number of times the data was stringified and parsed (stringified data getting re-stringified)

Found where JSON was being passed into JavaScript without being parsed first and fixed.

## Testing ##

Before testing on this branch, observe on `develop` that after completing the first few pages of questions and saving then refreshing, that the text input is in double quotes, selects are empty, and widget data does not load. This is because the data being fed in is a string of JSON.

With this branch checked out, complete the same actions and observe that after saving and reloading there are no double quotes on text inputs, selects are populated, and the filter image shows previous data.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
