### PR TITLE
[EPO-8793] Narrower max container width 

### DIFF
--- a/app/[locale]/[investigation]/review/page.tsx
+++ b/app/[locale]/[investigation]/review/page.tsx
@@ -13,7 +13,7 @@ const ReviewPage: FunctionComponent<ReviewPageProps> = () => {
   const nameInputId = "name";
 
   return (
-    <Styled.PageContainer>
+    <Styled.PageContainer width="narrow">
       <h1>Great job! Let’s review your answers.</h1>
       <form>
         <Styled.NameLabel htmlFor={nameInputId}>

--- a/components/templates/HomePage/index.tsx
+++ b/components/templates/HomePage/index.tsx
@@ -54,14 +54,14 @@ export default function HomePage(props: {
   if (!data) return null;
 
   return (
-    <Styled.ContentBlocks paddingSize="none" width="wide">
+    <Styled.PageContainer paddingSize="none" width="narrow">
       <Styled.Title>{data.title}</Styled.Title>
       {data.contentBlocks?.map(
         (block, i) =>
           block && <ContentBlockFactory key={i} site={data.site} data={block} />
       )}
       {/* {props.children} */}
-    </Styled.ContentBlocks>
+    </Styled.PageContainer>
   );
 }
 

--- a/components/templates/HomePage/styles.ts
+++ b/components/templates/HomePage/styles.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import { fluidScale } from "@rubin-epo/epo-react-lib/styles";
 
-export const ContentBlocks = styled(Container)`
+export const PageContainer = styled(Container)`
   --content-block-margin: ${fluidScale(
     "var(--PADDING_MEDIUM, 40px)",
     "var(--PADDING_SMALL, 20px)"

--- a/components/templates/InvestigationChildPage/index.tsx
+++ b/components/templates/InvestigationChildPage/index.tsx
@@ -33,7 +33,7 @@ const InvestigationChildPage: FunctionComponent<{
   if (!data?.title) return null;
 
   return (
-    <Styled.ContentBlocks paddingSize="none" width="wide">
+    <Styled.PageContainer paddingSize="none" width="narrow">
       <Styled.Title>{data.title}</Styled.Title>
       {data.contentBlocks?.map(
         (block, i) =>
@@ -46,7 +46,7 @@ const InvestigationChildPage: FunctionComponent<{
           userStatus={userStatus}
         />
       )}
-    </Styled.ContentBlocks>
+    </Styled.PageContainer>
   );
 };
 

--- a/components/templates/InvestigationChildPage/styles.ts
+++ b/components/templates/InvestigationChildPage/styles.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import { fluidScale } from "@rubin-epo/epo-react-lib/styles";
 
-export const ContentBlocks = styled(Container)`
+export const PageContainer = styled(Container)`
   --content-block-margin: ${fluidScale(
     "var(--PADDING_MEDIUM, 40px)",
     "var(--PADDING_SMALL, 20px)"

--- a/components/templates/InvestigationLandingPage/index.tsx
+++ b/components/templates/InvestigationLandingPage/index.tsx
@@ -45,7 +45,7 @@ const InvestigationLandingPage: FunctionComponent<{
   if (!title) return null;
 
   return (
-    <Styled.LandingPageContainer bgColor="orange05" paddingSize="medium">
+    <Styled.PageContainer bgColor="orange05" paddingSize="medium" width="narrow">
       <h1>{title}</h1>
       {image.length > 0 && (
         <Styled.Image image={imageShaper(props.site, image[0])} />
@@ -66,7 +66,7 @@ const InvestigationLandingPage: FunctionComponent<{
           </>
         )}
       </Styled.AuthWrapper>
-    </Styled.LandingPageContainer>
+    </Styled.PageContainer>
   );
 };
 

--- a/components/templates/InvestigationLandingPage/styles.ts
+++ b/components/templates/InvestigationLandingPage/styles.ts
@@ -7,7 +7,7 @@ import {
   BREAK_DESKTOP,
 } from "@/styles/globalStyles";
 
-export const LandingPageContainer = styled(Container)`
+export const PageContainer = styled(Container)`
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;

--- a/components/templates/InvestigationSectionBreakPage/index.tsx
+++ b/components/templates/InvestigationSectionBreakPage/index.tsx
@@ -52,7 +52,7 @@ const InvestigationSectionBreakPage: FunctionComponent<{
   const imgSrc = srcs[isFinalPage ? `final_${language}` : "break"];
 
   return (
-    <Container>
+    <Container width="narrow">
       <Image {...imgSrc} width={1260} height={560} />
       <Styled.SectionBreakTitle>
         {t(

--- a/components/templates/Page/index.tsx
+++ b/components/templates/Page/index.tsx
@@ -23,7 +23,7 @@ const Page: FunctionComponent<{ data: FragmentType<typeof Fragment> }> = (
   if (!data) return null;
 
   return (
-    <Container>
+    <Container width="narrow">
       <h1>{data.title}</h1>
       {data.contentBlocks?.map(
         (block, i) => block && <ContentBlockFactory key={i} data={block} />

--- a/components/templates/ReferenceContentPage/index.tsx
+++ b/components/templates/ReferenceContentPage/index.tsx
@@ -68,7 +68,7 @@ const ReferenceContentPage: FunctionComponent<{
   const { title, id } = data;
 
   return (
-    <Styled.ContentBlocks paddingSize="none" width="wide" bgColor="transparent">
+    <Styled.PageContainer paddingSize="none" width="narrow" bgColor="transparent">
       <Styled.Title>{title}</Styled.Title>
       {data.contentBlocks?.map(
         (block, i) =>
@@ -83,7 +83,7 @@ const ReferenceContentPage: FunctionComponent<{
             />
           )
       )}
-    </Styled.ContentBlocks>
+    </Styled.PageContainer>
   );
 };
 

--- a/components/templates/ReferenceContentPage/styles.ts
+++ b/components/templates/ReferenceContentPage/styles.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Container from "@rubin-epo/epo-react-lib/Container";
 import { fluidScale } from "@rubin-epo/epo-react-lib/styles";
 
-export const ContentBlocks = styled(Container)`
+export const PageContainer = styled(Container)`
   --content-block-margin: ${fluidScale(
     "var(--PADDING_MEDIUM, 40px)",
     "var(--PADDING_SMALL, 20px)"


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-8793>

## What this change does ##

Wherever `Container` is used gets the `width="narrow"` prop to approximate the max container width shown in design.  It's still a bit wider than in the design (by around 100px) but feels....fine?

## Notes for reviewers ##

Chances the `Container` on homepage, investigation landing page, investigation child page, review page, and reference content page.

## Testing ##

Please visually inspect on all effected page layouts at desktop and mobile screen widths.