### PR TITLE
[C] interaction groups span screen width on mobile

### DIFF
--- a/components/content-blocks/InteractionGroupContainer/styles.ts
+++ b/components/content-blocks/InteractionGroupContainer/styles.ts
@@ -1,19 +1,24 @@
 import styled from "styled-components";
-import { fluidScale } from "@rubin-epo/epo-react-lib/styles";
+import { fluidScale, token } from "@rubin-epo/epo-react-lib/styles";
 
 export const Heading = styled.h2`
   margin-block-end: ${fluidScale("2em", "1.5em")};
 `;
 export const InteractionGroup = styled.div`
-  --content-block-margin: ${fluidScale(
-    "var(--PADDING_MEDIUM, 40px)",
-    "var(--PADDING_SMALL, 20px)"
-  )};
+  --interaction-group-margin: var(
+    --content-block-margin,
+    ${fluidScale("var(--PADDING_MEDIUM, 40px)", "var(--PADDING_SMALL, 20px)")}
+  );
 
-  padding: ${fluidScale("2em", "1.5em")};
+  padding: var(--interaction-group-margin);
+  margin-inline: calc(-1 * var(--interaction-group-margin));
   background-color: #e6ffe6;
 
   > * + * {
-    margin-block-start: var(--content-block-margin);
+    margin-block-start: var(--interaction-group-margin);
+  }
+
+  @media screen and (min-width: ${token("BREAK_TABLET_MIN")}) {
+    margin-inline: 0;
   }
 `;


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-8805

## What this change does ##

Use negative margins and media queries to make interaction group span full screen width on mobile sizes.

![image](https://github.com/lsst-epo/investigations-client/assets/11721838/446baeea-feb2-4c2e-be43-84cad601a277)

