### PR TITLE
[C] add error parser to signup

### DIFF
--- a/components/auth/dialogs/SignUp/SignUp.tsx
+++ b/components/auth/dialogs/SignUp/SignUp.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { BasicModal, Input } from "@rubin-epo/epo-react-lib";
+import BasicModal from "@rubin-epo/epo-react-lib/BasicModal";
+import FormButtons from "@rubin-epo/epo-react-lib/FormButtons";
+import Button from "@rubin-epo/epo-react-lib/Button";
+import Submit from "@/components/form/Submit";
 import { useAuthDialogManager } from "@/contexts/AuthDialogManager";
 import { registerEducator, registerStudent } from "./actions";
 import { useTranslation } from "react-i18next";
@@ -11,17 +14,14 @@ export default function SignUp() {
   const { active, pendingGroup, openModal, closeModal } =
     useAuthDialogManager();
 
-  const [status, setStatus] = useState<"error" | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const { t } = useTranslation();
 
   function getTitle() {
-    switch (status) {
-      case "error":
-        return t("register.error");
-      default:
-        return t("register.header", { context: pendingGroup });
-    }
+    if (error !== null) return t("register.error");
+
+    return t("register.header", { context: pendingGroup });
   }
 
   return (
@@ -30,7 +30,7 @@ export default function SignUp() {
       open={active === "signUp"}
       onClose={closeModal}
     >
-      <form
+      <Styled.SignUpForm
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         action={async (formData: FormData) => {
@@ -46,83 +46,75 @@ export default function SignUp() {
                 openModal("statusPending");
               }
             }
-          } catch (error) {
-            setStatus("error");
-          }
 
-          setStatus(null);
+            setError(null);
+          } catch (error) {
+            setError((error as Error).message);
+          }
         }}
       >
-        <Styled.InputWrapper>
-          <Styled.Label htmlFor="signUpEmail">
-            {t("form.email_required")}
-          </Styled.Label>
-          <Input
+        <Styled.Label>
+          {t("form.email_required")}
+          <Styled.Input
             name="email"
             id="signUpEmail"
             type="email"
             autoComplete="email"
             required
           />
-        </Styled.InputWrapper>
-        <Styled.InputWrapper>
-          <Styled.Label htmlFor="registerFirstName">
-            {t("form.first_name_optional")}
-          </Styled.Label>
-          <Input
+        </Styled.Label>
+        <Styled.Label>
+          {t("form.first_name_optional")}
+          <Styled.Input
             name="firstName"
             id="registerFirstName"
             type="text"
             autoComplete="given-name"
           />
-        </Styled.InputWrapper>
-        <Styled.InputWrapper>
-          <Styled.Label htmlFor="registerLastName">
-            {t("form.last_name_optional")}
-          </Styled.Label>
-          <Input
+        </Styled.Label>
+        <Styled.Label>
+          {t("form.last_name_optional")}
+          <Styled.Input
             name="lastName"
             id="registerLastName"
             type="text"
             autoComplete="family-name"
           />
-        </Styled.InputWrapper>
-        <Styled.InputWrapper>
-          <Styled.Label htmlFor="signUpPassword">
-            {t("form.password_required")}
-            <Styled.Instructions>
-              {t("form.create_password_instructions")}
-            </Styled.Instructions>
-          </Styled.Label>
-          <Input
+        </Styled.Label>
+        <Styled.Label>
+          {t("form.password_required")}
+          <Styled.Instructions>
+            {t("form.create_password_instructions")}
+          </Styled.Instructions>
+          <Styled.Input
             name="password"
             id="signUpPassword"
             type="password"
             autoComplete="current-password"
+            minLength={6}
             required
           />
-        </Styled.InputWrapper>
-        <Styled.ButtonsWrapper>
-          <Styled.SubmitButton>
+        </Styled.Label>
+        <FormButtons>
+          <Submit>
             {(pending) =>
               t(pending ? "register.submit_pending" : "register.submit")
             }
-          </Styled.SubmitButton>
-          <Styled.CancelButton
+          </Submit>
+          <Button
+            id="signUpButton"
             type="button"
             styleAs="secondary"
             onClick={() => {
-              setStatus(null);
+              setError(null);
               closeModal();
             }}
           >
             {t("form.cancel")}
-          </Styled.CancelButton>
-        </Styled.ButtonsWrapper>
-        <output>
-          {status === "error" && <p>{t("register.error_message")}</p>}
-        </output>
-      </form>
+          </Button>
+        </FormButtons>
+        <output>{error}</output>
+      </Styled.SignUpForm>
     </BasicModal>
   );
 }

--- a/components/auth/dialogs/SignUp/styles.ts
+++ b/components/auth/dialogs/SignUp/styles.ts
@@ -1,39 +1,21 @@
 import styled from "styled-components";
-import { Button } from "@rubin-epo/epo-react-lib";
-import Submit from "@/components/form/Submit";
+import BaseInput from "@rubin-epo/epo-react-lib/Input";
 
-export const InputWrapper = styled.div`
-  margin-top: 20px;
+export const SignUpForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--PADDING_SMALL, 20px);
+  margin-block-start: var(--PADDING_SMALL, 20px);
 `;
 
 export const Label = styled.label`
-  font-weight: 700;
-  line-height: 1.5;
+  font-weight: var(--FONT_WEIGHT_BOLD, 600);
+`;
+
+export const Input = styled(BaseInput)`
+  font-weight: var(--FONT_WEIGHT_NORMAL, 400);
 `;
 
 export const Instructions = styled.div`
-  color: #313333;
-  font-weight: 400;
-  line-height: 1.5;
-  font-size: 14px;
-`;
-
-export const ButtonsWrapper = styled.div`
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 20px;
-`;
-
-const buttonWidth = `
-  width: calc(50% - 10px);
-`;
-
-export const SubmitButton = styled(Submit)`
-  ${buttonWidth}
-`;
-
-export const CancelButton = styled(Button)`
-  ${buttonWidth}
+  font-weight: var(--FONT_WEIGHT_NORMAL, 400);
 `;

--- a/public/localeStrings/en/translation.json
+++ b/public/localeStrings/en/translation.json
@@ -54,7 +54,7 @@
     "show_password": "Show password",
     "hide_password": "Hide password",
     "create_password": "Create a password (required)",
-    "create_password_instructions": "Passwords should be at least 8 characters long and should contain a mixture of letters, numbers, and other characters.",
+    "create_password_instructions": "Passwords should be at least 6 characters long and should contain a mixture of letters, numbers, and other characters.",
     "school": "School",
     "preferred_language": "Preferred language",
     "email_subscription": "Email subscription",
@@ -190,7 +190,10 @@
     "success_message_educators": "Your account is now created, but activation is pending. You’ll receive an email with instructions to activate your account and enjoy access to real astronomy data and tools. <strong>Free of charge forever.</strong>",
     "confirm_button": "Got it!",
     "error": "Error!",
-    "error_message": "There was an error signing you up."
+    "error_message": "There was an error signing you up.",
+    "error_username_taken": "Username has already been taken.",
+    "error_email_invalid": "Email is not a valid email address.",
+    "error_password_invalid": "Password does not meet requirements."
   },
   "account": {
     "header": "Account",

--- a/public/localeStrings/es/translation.json
+++ b/public/localeStrings/es/translation.json
@@ -45,7 +45,7 @@
     "show_password": "Mostrar contraseña",
     "hide_password": "Ocultar contraseña",
     "create_password": "Crear una contraseña (requerido)",
-    "create_password_instructions": "Las contraseñas deben tener como mínimo 8 caracteres y deben tener una combinación de letras, números y símbolos.",
+    "create_password_instructions": "Las contraseñas deben tener como mínimo 6 caracteres y deben tener una combinación de letras, números y símbolos.",
     "school": "Escuela",
     "preferred_language": "Idioma preferido",
     "email_subscription": "Suscripción al correo electrónico",


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-8841

## What this change does ##

"error" status was not reflecting properly in signup. Address this bug and additionally put an error parser in that interprets the GraphQL errors into a translateable message.

## Notes for reviewers ##

Client-only

Include an indication of how detailed a review you want on a 1-10 scale.
- 3

## Testing ##

Test the following cases:

- Create a new account with an email that is already signed up
- Create a new account with an invalid email (ex. a@b.)
- Create a new account with a password that does not meet the minimum length (frontend validation was added on this as well so the error catch may be unnecessary)

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
