### PR TITLE
[C] use Craft caption as fallback

### DIFF
--- a/components/content-blocks/Image/Image.tsx
+++ b/components/content-blocks/Image/Image.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from "react";
 import { graphql, useFragment, FragmentType } from "@/gql/public-schema";
-import { useTranslation } from "react-i18next";
 import withModal from "@/components/hoc/withModal/withModal";
 import { BaseContentBlockProps } from "@/components/shapes";
 import { imageShaper } from "@/helpers";
@@ -45,7 +44,6 @@ interface ImageContentBlockProps extends BaseContentBlockProps {
 const ImageContentBlock: FunctionComponent<ImageContentBlockProps> = (
   props
 ) => {
-  const { t } = useTranslation();
   const { data, site, isOpen, openModal } = props;
   const {
     layout,
@@ -58,16 +56,7 @@ const ImageContentBlock: FunctionComponent<ImageContentBlockProps> = (
 
   if (!image) return null;
 
-  const { width, caption = fallbackCaption, credit } = image;
-
-  const figCaption = `${caption !== null ? caption : ""}${
-    credit
-      ? ` ${t("translation:image.credit", {
-          credit,
-          interpolation: { escapeValue: false },
-        })}`
-      : ""
-  }`;
+  const { width, caption } = image;
 
   return (
     <Styled.Container
@@ -87,7 +76,7 @@ const ImageContentBlock: FunctionComponent<ImageContentBlockProps> = (
         />
       )}
       <Styled.Figure
-        caption={figCaption}
+        caption={caption || fallbackCaption || undefined}
         $layout={finalLayout}
         $darkMode={isOpen}
         withBackground={!isOpen}

--- a/components/content-blocks/Image/Image.tsx
+++ b/components/content-blocks/Image/Image.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from "react";
 import { graphql, useFragment, FragmentType } from "@/gql/public-schema";
+import { useTranslation } from "react-i18next";
 import withModal from "@/components/hoc/withModal/withModal";
 import { BaseContentBlockProps } from "@/components/shapes";
 import { imageShaper } from "@/helpers";
@@ -44,11 +45,12 @@ interface ImageContentBlockProps extends BaseContentBlockProps {
 const ImageContentBlock: FunctionComponent<ImageContentBlockProps> = (
   props
 ) => {
+  const { t } = useTranslation();
   const { data, site, isOpen, openModal } = props;
   const {
     layout,
     image: rawImage,
-    caption: fallbackCaption = "",
+    caption: craftCaption = "",
   } = useFragment(Fragment, data);
   const finalLayout = isOpen ? "vertical" : layout;
 
@@ -56,7 +58,16 @@ const ImageContentBlock: FunctionComponent<ImageContentBlockProps> = (
 
   if (!image) return null;
 
-  const { width, caption } = image;
+  const { width, caption: cantoCaption, credit } = image;
+
+  const caption = `${craftCaption || cantoCaption || ""}${
+    credit
+      ? ` ${t("translation:image.credit", {
+          credit,
+          interpolation: { escapeValue: false },
+        })}`
+      : ""
+  }`;
 
   return (
     <Styled.Container
@@ -76,7 +87,7 @@ const ImageContentBlock: FunctionComponent<ImageContentBlockProps> = (
         />
       )}
       <Styled.Figure
-        caption={caption || fallbackCaption || undefined}
+        caption={caption}
         $layout={finalLayout}
         $darkMode={isOpen}
         withBackground={!isOpen}

--- a/components/content-blocks/Image/styles.ts
+++ b/components/content-blocks/Image/styles.ts
@@ -1,8 +1,6 @@
 import styled, { css } from "styled-components";
-import {
-  Figure as BaseFigure,
-  Image as BaseImage,
-} from "@rubin-epo/epo-react-lib";
+import BaseImage from "@rubin-epo/epo-react-lib/Image";
+import BaseFigure from "@rubin-epo/epo-react-lib/Figure";
 import BaseExpandContract from "@/atomic/ExpandContract/ExpandContract";
 import { BREAK_PHABLET } from "@/styles/globalStyles";
 


### PR DESCRIPTION
For JIRA: "EPO-8856 #IN-REVIEW #comment use Craft caption as fallback"

JIRA: https://jira.lsstcorp.org/browse/EPO-8856

## What this change does ##

Instead of concatenating the Craft "caption" field to the Canto caption field, use it as a fallback (mostly for i18n)

## Notes for reviewers ##

Client change mainly but the API 

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"

## Testing ##

View an image that does not have a caption written in Craft, the caption + credit from Canto should be used. Add a caption in Craft and check again, it should use this caption instead.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
