### PR TITLE
[C] question server rendering + a11y fix

### DIFF
--- a/components/content-blocks/Questions/index.tsx
+++ b/components/content-blocks/Questions/index.tsx
@@ -1,8 +1,7 @@
-"use client";
 import { FunctionComponent } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "@/lib/i18n";
 import { graphql, useFragment, FragmentType } from "@/gql/public-schema";
-import useQuestions from "@/contexts/Questions";
+import { BaseContentBlockProps } from "@/components/shapes";
 import QuestionFactory from "@/components/factories/QuestionFactory";
 import * as Styled from "./styles";
 
@@ -16,19 +15,12 @@ const Fragment = graphql(`
   }
 `);
 
-interface QuestionsContentBlockProps {
-  data: FragmentType<typeof Fragment>;
-  isInteraction?: boolean;
-}
-
-const QuestionsContentBlock: FunctionComponent<QuestionsContentBlockProps> = ({
-  isInteraction = false,
-  ...props
-}) => {
+const QuestionsContentBlock: FunctionComponent<
+  BaseContentBlockProps<FragmentType<typeof Fragment>>
+> = async ({ isInteraction = false, locale, ...props }) => {
   const data = useFragment(Fragment, props.data);
 
-  const { t } = useTranslation();
-  const questions = useQuestions();
+  const { t } = await useTranslation(locale, "translation");
 
   return (
     <section className="content-block">
@@ -39,18 +31,9 @@ const QuestionsContentBlock: FunctionComponent<QuestionsContentBlockProps> = ({
         }}
       >
         {!!data.questionEntries?.length &&
-          data.questionEntries.map((question) => {
-            const { id } = question;
-            const questionIndex = questions.byAll.findIndex(
-              (question) => question.id === id
-            );
-
+          data.questionEntries.map((question, i) => {
             return question?.__typename === "questions_default_Entry" ? (
-              <QuestionFactory
-                key={id}
-                data={question}
-                number={questionIndex + 1}
-              />
+              <QuestionFactory key={i} data={question} />
             ) : null;
           })}
       </Styled.QuestionList>

--- a/components/content-blocks/Questions/styles.ts
+++ b/components/content-blocks/Questions/styles.ts
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 
 export const Heading = styled.h2`

--- a/components/factories/QuestionFactory/index.tsx
+++ b/components/factories/QuestionFactory/index.tsx
@@ -71,7 +71,6 @@ const Fragment = graphql(`
 
 export interface QuestionProps {
   data: FragmentType<typeof Fragment>;
-  number: number;
 }
 
 const QUESTION_MAP: Record<string, ComponentType<any>> = {
@@ -83,10 +82,7 @@ const QUESTION_MAP: Record<string, ComponentType<any>> = {
   multiPart: InlineQuestion,
 };
 
-const QuestionFactory: FunctionComponent<QuestionProps> = ({
-  number,
-  ...props
-}) => {
+const QuestionFactory: FunctionComponent<QuestionProps> = ({ ...props }) => {
   const {
     answerType: type,
     id,
@@ -111,7 +107,7 @@ const QuestionFactory: FunctionComponent<QuestionProps> = ({
   return (
     <Question
       questionText={questionText || widgetInstructions}
-      {...{ id, type, options, widgetConfig, number, parts }}
+      {...{ id, type, options, widgetConfig, parts }}
     />
   );
 };

--- a/components/questions/InlineQuestion/index.tsx
+++ b/components/questions/InlineQuestion/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { ComponentType, FunctionComponent, useContext } from "react";
 import { Option } from "@/components/shapes/option";
 import { BaseQuestionProps, InlineQuestionType } from "@/types/questions";
@@ -46,7 +47,6 @@ const INPUT_MAP: Record<InlineQuestionType, ComponentType<any>> = {
 
 const InlineQuestion: FunctionComponent<InlineQuestionProps> = ({
   id,
-  number,
   isDisabled,
   parts = [],
 }) => {
@@ -55,7 +55,7 @@ const InlineQuestion: FunctionComponent<InlineQuestionProps> = ({
   const { data = {} } = storedAnswer;
 
   return (
-    <Styled.InlineContainer value={number}>
+    <Styled.InlineContainer id={id}>
       {parts.map(({ id: partId, type, ...props }) => {
         const Input = INPUT_MAP[type];
 

--- a/components/questions/InlineQuestion/styles.ts
+++ b/components/questions/InlineQuestion/styles.ts
@@ -1,7 +1,8 @@
 "use client";
 import styled from "styled-components";
+import QuestionNumber from "../QuestionNumber";
 
-export const InlineContainer = styled.li`
+export const InlineContainer = styled(QuestionNumber)`
   > * + * {
     margin: 0;
     margin-inline-start: 0.5ch;

--- a/components/questions/QuestionNumber/index.tsx
+++ b/components/questions/QuestionNumber/index.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import useQuestions from "@/contexts/Questions";
+import { FunctionComponent, PropsWithChildren } from "react";
+
+const QuestionNumber: FunctionComponent<
+  PropsWithChildren<{ id: string; className?: string }>
+> = ({ id, className, children }) => {
+  const questions = useQuestions();
+
+  const questionIndex = questions.byAll.findIndex(
+    (question) => question.id === id
+  );
+
+  return (
+    <li value={questionIndex + 1} className={className}>
+      {children}
+    </li>
+  );
+};
+
+QuestionNumber.displayName = "Questions.Number";
+
+export default QuestionNumber;

--- a/components/questions/SimpleQuestion/Multiselect/index.tsx
+++ b/components/questions/SimpleQuestion/Multiselect/index.tsx
@@ -9,7 +9,6 @@ interface SimpleMultiselectProps {
   isDisabled?: boolean;
   onChangeCallback: (value: string[] | null) => void;
   options: Option[];
-  labelledById: string;
 }
 
 const SimpleMultiselect: FunctionComponent<SimpleMultiselectProps> = ({
@@ -18,13 +17,11 @@ const SimpleMultiselect: FunctionComponent<SimpleMultiselectProps> = ({
   isDisabled,
   onChangeCallback,
   options = [],
-  labelledById,
 }) => {
   const { t } = useTranslation();
   return (
     <Styled.Select
       placeholder={t("translation:placeholder.select")}
-      labelledById={labelledById}
       id={id}
       value={value}
       isDisabled={isDisabled}

--- a/components/questions/SimpleQuestion/Select/index.tsx
+++ b/components/questions/SimpleQuestion/Select/index.tsx
@@ -9,7 +9,6 @@ interface SimpleSelectProps {
   isDisabled?: boolean;
   onChangeCallback: (value: string | null) => void;
   options: Option[];
-  labelledById: string;
 }
 
 const SimpleSelect: FunctionComponent<SimpleSelectProps> = ({
@@ -18,13 +17,11 @@ const SimpleSelect: FunctionComponent<SimpleSelectProps> = ({
   isDisabled,
   onChangeCallback,
   options = [],
-  labelledById,
 }) => {
   const { t } = useTranslation();
   return (
     <Styled.Select
       placeholder={t("translation:placeholder.select")}
-      labelledById={labelledById}
       id={id}
       value={value || null}
       isDisabled={isDisabled}

--- a/components/questions/SimpleQuestion/Text/index.tsx
+++ b/components/questions/SimpleQuestion/Text/index.tsx
@@ -6,7 +6,6 @@ interface SimpleTextProps {
   value?: string;
   isDisabled?: boolean;
   onChangeCallback: (value: string) => void;
-  labelledById: string;
 }
 
 const SimpleText: FunctionComponent<SimpleTextProps> = ({
@@ -14,11 +13,9 @@ const SimpleText: FunctionComponent<SimpleTextProps> = ({
   value,
   isDisabled,
   onChangeCallback,
-  labelledById,
 }) => {
   return (
     <Styled.TextInput
-      aria-labelledby={labelledById}
       id={id}
       type="text"
       disabled={isDisabled}

--- a/components/questions/SimpleQuestion/Textarea/index.tsx
+++ b/components/questions/SimpleQuestion/Textarea/index.tsx
@@ -6,7 +6,6 @@ interface SimpleTextareaProps {
   value?: string;
   isDisabled?: boolean;
   onChangeCallback: (value: string) => void;
-  labelledById?: string;
 }
 
 const SimpleTextarea: FunctionComponent<SimpleTextareaProps> = ({
@@ -14,11 +13,9 @@ const SimpleTextarea: FunctionComponent<SimpleTextareaProps> = ({
   value,
   isDisabled,
   onChangeCallback,
-  labelledById,
 }) => {
   return (
     <Styled.Textarea
-      aria-labelledby={labelledById}
       as="textarea"
       rows={3}
       disabled={isDisabled}

--- a/components/questions/SimpleQuestion/index.tsx
+++ b/components/questions/SimpleQuestion/index.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { ComponentType, FunctionComponent, useContext } from "react";
 import { BaseQuestionProps, SimpleQuestionType } from "@/types/questions";
 import { Option } from "@/components/shapes/option";
@@ -29,7 +28,6 @@ const INPUT_MAP: Record<SimpleQuestionType, ComponentType<any>> = {
 
 const SimpleQuestion: FunctionComponent<SimpleQuestionProps> = ({
   id,
-  number,
   type,
   questionText,
   options,
@@ -39,7 +37,6 @@ const SimpleQuestion: FunctionComponent<SimpleQuestionProps> = ({
   const { answers, onChangeCallback } = useContext(StoredAnswersContext);
 
   const storedAnswer = answers[id];
-  const labelId = `${id}Label`;
 
   const Input = INPUT_MAP[type];
 
@@ -50,10 +47,9 @@ const SimpleQuestion: FunctionComponent<SimpleQuestionProps> = ({
   }
 
   return (
-    <Styled.SimpleContainer value={number}>
+    <Styled.SimpleContainer id={id}>
       {type === "widget" ? (
         <Styled.QuestionLabel
-          id={labelId}
           dangerouslySetInnerHTML={{ __html: questionText }}
         />
       ) : (
@@ -64,7 +60,6 @@ const SimpleQuestion: FunctionComponent<SimpleQuestionProps> = ({
           onChangeCallback && onChangeCallback(value, id, storedAnswer?.id)
         }
         value={storedAnswer?.data}
-        labelledById={labelId}
         {...{
           isDisabled,
           id,

--- a/components/questions/SimpleQuestion/styles.ts
+++ b/components/questions/SimpleQuestion/styles.ts
@@ -1,7 +1,8 @@
 "use client";
 import styled from "styled-components";
+import QuestionNumber from "../QuestionNumber";
 
-export const SimpleContainer = styled.li`
+export const SimpleContainer = styled(QuestionNumber)`
   & > * + * {
     margin-block-start: var(--PADDING_SMALL, 20px);
   }

--- a/components/questions/TabularQuestion/Select/index.tsx
+++ b/components/questions/TabularQuestion/Select/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import * as Styled from "./styles";

--- a/components/questions/TabularQuestion/Text/styles.ts
+++ b/components/questions/TabularQuestion/Text/styles.ts
@@ -1,3 +1,4 @@
+"use client";
 import styled from "styled-components";
 import { TextInput as BaseTextInput } from "../../SimpleQuestion/Text/styles";
 

--- a/components/questions/TabularQuestion/index.tsx
+++ b/components/questions/TabularQuestion/index.tsx
@@ -4,6 +4,7 @@ import { Option } from "@/components/shapes/option";
 import { BaseQuestionProps, TabularQuestionType } from "@/types/questions";
 import Text from "./Text";
 import Select from "./Select";
+import QuestionNumber from "../QuestionNumber";
 
 interface QuestionCell {
   id: string;
@@ -28,7 +29,6 @@ const INPUT_MAP: Record<TabularQuestionType, ComponentType<any>> = {
 
 const TabularQuestion: FunctionComponent<TabularQuestionProps> = ({
   id,
-  number,
   isDisabled,
   header = [],
   rowHeader = [],
@@ -63,9 +63,9 @@ const TabularQuestion: FunctionComponent<TabularQuestionProps> = ({
   });
 
   return (
-    <li value={number}>
+    <QuestionNumber id={id}>
       <Table id={id} {...{ header, rows }} />
-    </li>
+    </QuestionNumber>
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "investigations-client",
   "author": "Rubin EPO",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/types/questions.d.ts
+++ b/types/questions.d.ts
@@ -21,7 +21,6 @@ export type TabularQuestionType = TextQuestion | SelectQuestion;
 
 export interface BaseQuestionProps {
   id: string;
-  number: number;
   isDisabled?: boolean;
 }
 


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-8995

## What this change does ##

Pushes client rendering out on the render tree by having the question number matched in a single component, not a vital change but has the potential to make further changes to stuff like widgets that may need larger libs rendered on the server. 

Also includes an A11Y to remove an incorrectly set `aria-labelledby` attribute.

## Notes for reviewers ##

Client only branch

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"

