### PR TITLE
[B] studentAuthData has student object for useFragment arg

### DIFF
--- a/components/auth/buttons/GoogleSSO/actions.ts
+++ b/components/auth/buttons/GoogleSSO/actions.ts
@@ -19,7 +19,6 @@ const oAuth2Client = new OAuth2Client(
 // exchanges Auth Code for Tokens
 export async function getTokens(code) {
   const { tokens } = await oAuth2Client.getToken(code);
-
   return tokens;
 }
 
@@ -80,12 +79,14 @@ export async function authenticateEducator(
     query: EducatorMutation,
     variables: { idToken },
   });
+
   // not actually a client-side hook, just named like one
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const authData = useFragment(
     AuthFragmentFragmentDoc,
     data?.googleSignInEducators
   );
+
   conditionallySetCookiesRevalidatePath(authData, pathToRevalidate, error);
 
   if (error) {
@@ -113,7 +114,7 @@ export async function authenticateUser(
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const studentAuthData = useFragment(
       AuthFragmentFragmentDoc,
-      studentData?.googleSignInEducators
+      studentData?.googleSignInStudents
     );
     conditionallySetCookiesRevalidatePath(studentAuthData, pathToRevalidate);
     // Returns if data so we don't hit the educator data fetch if we don't need it

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -87,7 +87,6 @@ export async function mutateAPI<
   previewToken?: string;
 }): Promise<OperationResult<Mutation, Variables>> {
   const url = previewToken ? `${API_URL}?token=${previewToken}` : API_URL;
-
   const client = createClient({
     url,
     exchanges: [fetchExchange],
@@ -95,7 +94,7 @@ export async function mutateAPI<
       if (!token) return {};
       return {
         headers: {
-          ...(token && { authorization: `JWT ${token}` }),
+          Authorization: `JWT ${token}`,
         },
       };
     },


### PR DESCRIPTION
To be reviewed alongside https://github.com/lsst-epo/investigations-api/pull/80

Please test:

- user creation with google auth and with username + password
- user login with google auth and with username + password

Note for reviewers:
 - In my testing the forget password link and the account activation emails are not sending correctly.  I am willing to believe this is a problem unique to local dev and so suggest testing those additional use cases after this work has been released to `dev`.
 - You will need an env var for the google secret in addition to the app id for the new client auth code to to work as expected.  @alexgoff you may already have those in there from my previous refactor of this google auth work, but if you need either ping @blnkt in Slack.