### PR TITLE
[B] fix select dropdown behind question text

### DIFF
--- a/components/content-blocks/Questions/index.tsx
+++ b/components/content-blocks/Questions/index.tsx
@@ -23,7 +23,7 @@ const QuestionsContentBlock: FunctionComponent<
   const { t } = await useTranslation(locale, "translation");
 
   return (
-    <section className="content-block" style={{ isolation: "isolate" }}>
+    <section className="content-block">
       {!isInteraction && <Styled.Heading>{t("page.questions")}</Styled.Heading>}
       <Styled.QuestionList
         style={{

--- a/components/content-blocks/Questions/index.tsx
+++ b/components/content-blocks/Questions/index.tsx
@@ -23,7 +23,7 @@ const QuestionsContentBlock: FunctionComponent<
   const { t } = await useTranslation(locale, "translation");
 
   return (
-    <section className="content-block">
+    <section className="content-block" style={{ isolation: "isolate" }}>
       {!isInteraction && <Styled.Heading>{t("page.questions")}</Styled.Heading>}
       <Styled.QuestionList
         style={{

--- a/components/content-blocks/Questions/styles.ts
+++ b/components/content-blocks/Questions/styles.ts
@@ -13,6 +13,7 @@ export const QuestionList = styled.ol`
 
   background-color: var(--list-background-color, transparent);
   color: var(--question-color);
+  isolation: isolate;
   list-style-type: decimal;
   list-style-position: inside;
   padding: var(--list-padding, 0);

--- a/components/questions/QuestionNumber/index.tsx
+++ b/components/questions/QuestionNumber/index.tsx
@@ -15,6 +15,7 @@ const QuestionNumber: FunctionComponent<
 > = ({ id, direction = "block", className, children }) => {
   const questions = useQuestions();
 
+  const maxIndex = questions.byAll.length - 1;
   const questionIndex = questions.byAll.findIndex(
     (question) => question.id === id
   );
@@ -24,6 +25,7 @@ const QuestionNumber: FunctionComponent<
       value={questionIndex + 1}
       data-direction={direction}
       className={className}
+      style={{ zIndex: maxIndex - questionIndex }}
     >
       {children}
     </Styled.Number>

--- a/components/questions/QuestionNumber/styles.ts
+++ b/components/questions/QuestionNumber/styles.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 export const Number = styled.li`
   container-type: inline-size;
+  position: relative;
 
   &[data-direction="block"] {
     & > * + * {


### PR DESCRIPTION
For JIRA: "EPO-9125 #IN-REVIEW #comment fix select dropdown behind question text"

JIRA: https://jira.lsstcorp.org/browse/<ID>

## What this change does ##

Select dropdowns are already given their own stacking context, however since the browser considers items added later in the DOM to be at a higher implicit z-index they end up rendering behind dropdowns in following questions.

To fix this, the questions index among all questions is used to assign a `z-index` to that specific question, in descending order (first question will have the highest z-index)

## Notes for reviewers ##

Change is clientside

Include an indication of how detailed a review you want on a 1-10 scale.
- 2

## Testing ##

Verified locally on Chrome, Safari, and Firefox. 

- Go to a page with multiple select questions (pages 6 and 10 in Coloring the Universe)
   - page 18 for additional verification, since it has the only non-inline selects that overlap
- Open select dropdowns, verify they do not overlap

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://github.com/lsst-epo/investigations-client/assets/11721838/19d98715-f120-417e-863f-0f7140e212d0)

### After:
![image](https://github.com/lsst-epo/investigations-client/assets/11721838/c2658a99-1502-4d50-bd1d-ea35abceac58)
