### PR TITLE
[C] limit image size

### DIFF
--- a/components/content-blocks/Image/index.ts
+++ b/components/content-blocks/Image/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./Image";

--- a/components/content-blocks/Image/styles.ts
+++ b/components/content-blocks/Image/styles.ts
@@ -3,10 +3,11 @@ import BaseFigure from "@rubin-epo/epo-react-lib/Figure";
 import BaseExpandContract from "@/atomic/ExpandContract/ExpandContract";
 
 export const Container = styled.section`
+  --target-height: 0.75;
   --figure-ui-size: calc(var(--content-gap) * 2);
   --figure-max-height: calc(
     calc(100vh - var(--global-ui-height) - var(--figure-ui-size)) *
-      var(--image-aspect-ratio)
+      var(--image-aspect-ratio) * var(--target-height)
   );
   --intrinsic-width: calc(var(--figure-ui-size) + var(--image-width));
   --figure-width: min(var(--intrinsic-width), var(--figure-max-height));
@@ -16,6 +17,7 @@ export const Container = styled.section`
   width: 100%;
 
   &[data-modal-open="true"] {
+    --target-height: 1;
     --figure-ui-size: 0px;
   }
 `;

--- a/components/content-blocks/Image/styles.ts
+++ b/components/content-blocks/Image/styles.ts
@@ -1,80 +1,48 @@
-import styled, { css } from "styled-components";
-import BaseImage from "@rubin-epo/epo-react-lib/Image";
+import styled from "styled-components";
 import BaseFigure from "@rubin-epo/epo-react-lib/Figure";
 import BaseExpandContract from "@/atomic/ExpandContract/ExpandContract";
-import { BREAK_PHABLET } from "@/styles/globalStyles";
-
-interface LayoutProp {
-  $layout: "vertical" | "horizontal";
-}
 
 export const Container = styled.section`
-  align-self: center;
-  max-width: var(--max-image-width);
+  --figure-ui-size: calc(var(--content-gap) * 2);
+  --figure-max-height: calc(
+    calc(100vh - var(--global-ui-height) - var(--figure-ui-size)) *
+      var(--image-aspect-ratio)
+  );
+  --intrinsic-width: calc(var(--figure-ui-size) + var(--image-width));
+  --figure-width: min(var(--intrinsic-width), var(--figure-max-height));
+
+  display: flex;
+  justify-content: center;
   width: 100%;
-  position: relative;
-`;
 
-export const Figure = styled(BaseFigure)<
-  LayoutProp & { $darkMode: boolean; $layout: string }
->`
-  ${({ $layout, $darkMode }) => css`
-    ${$darkMode &&
-    css`
-      > figcaption {
-        color: var(--white, #fff);
-        padding-block: var(--image-content-block-padding);
-        padding-inline: var(--image-content-block-padding);
-      }
-    `}
-    ${$layout === "horizontal" &&
-    css`
-      > figcaption {
-        margin: 0;
-        padding: 0;
-      }
-    `}
-  padding: var(--image-content-block-padding, 0);
-  `}
-
-  &:after {
-    content: "";
-    visibility: hidden;
-    display: block;
-    height: 0;
-    clear: both;
+  &[data-modal-open="true"] {
+    --figure-ui-size: 0px;
   }
 `;
 
-export const Image = styled(BaseImage)<LayoutProp>`
-  ${({ $layout }) => css`
-    ${$layout === "horizontal" &&
-    css`
-      @media (min-width: ${BREAK_PHABLET}) {
-        @supports (float: inline-start) {
-          float: inline-start;
-        }
+export const Figure = styled(BaseFigure)`
+  position: relative;
+  padding: var(--content-gap, 0);
+  width: var(--figure-width);
+  max-width: 100%;
 
-        float: left;
-        margin-inline-end: var(--image-content-block-padding);
-        max-inline-size: 50%;
-      }
-    `}
-  `};
+  &[data-layout="horizontal"] {
+    --expand-contract-left: calc(var(--content-gap) * 1.25);
+    --expand-contract-right: auto;
+
+    --intrinsic-width: calc(
+      var(--figure-ui-size) + calc(var(--image-width) * 2)
+    );
+  }
 `;
 
-export const ExpandContract = styled(BaseExpandContract)<LayoutProp>`
-  --expand-contract-offset: calc(var(--image-content-block-padding) * 1.25);
-  position: absolute;
-  top: var(--expand-contract-offset);
-  right: var(--expand-contract-offset);
+export const Image = styled.img``;
 
-  ${({ $layout }) =>
-    $layout === "horizontal" &&
-    css`
-      @media (min-width: ${BREAK_PHABLET}) {
-        right: auto;
-        left: var(--expand-contract-offset);
-      }
-    `}
+export const ExpandContract = styled(BaseExpandContract)`
+  --expand-contract-offset: calc(var(--content-gap) * 1.25);
+
+  position: absolute !important;
+  top: var(--expand-contract-offset);
+  right: var(--expand-contract-right, var(--expand-contract-offset));
+  left: var(--expand-contract-left, auto);
 `;

--- a/components/content-blocks/Video/index.tsx
+++ b/components/content-blocks/Video/index.tsx
@@ -5,6 +5,7 @@ import { BaseContentBlockProps } from "@/components/shapes";
 import { FragmentType, graphql, useFragment } from "@/gql/public-schema";
 import { captionShaper, videoShaper } from "@/helpers";
 import { useTranslation } from "@/lib/i18n";
+import * as Styled from "./styles";
 
 const Fragment = graphql(`
   fragment VideoBlock on contentBlocks_video_BlockType {
@@ -38,24 +39,31 @@ const VideoBlock: FunctionComponent<
 
   if (!video) return null;
 
-  const { caption: fallback, credit } = video;
+  const { caption: fallback, credit, width, height } = video;
 
   return (
-    <Figure
-      withBackground
-      caption={captionShaper({
-        caption,
-        fallback,
-        credit:
-          credit &&
-          ` ${t("translation:image.credit", {
-            credit,
-            interpolation: { escapeValue: false },
-          })}`,
-      })}
+    <Styled.Container
+      style={{
+        "--video-aspect-ratio": width / height,
+        "--video-width": `${width}px`,
+      }}
     >
-      <Video {...video} />
-    </Figure>
+      <Figure
+        withBackground
+        caption={captionShaper({
+          caption,
+          fallback,
+          credit:
+            credit &&
+            ` ${t("translation:image.credit", {
+              credit,
+              interpolation: { escapeValue: false },
+            })}`,
+        })}
+      >
+        <Video {...{ ...video, width, height }} />
+      </Figure>
+    </Styled.Container>
   );
 };
 

--- a/components/content-blocks/Video/styles.ts
+++ b/components/content-blocks/Video/styles.ts
@@ -1,0 +1,16 @@
+"use client";
+import styled from "styled-components";
+
+export const Container = styled.section`
+  --figure-ui-size: calc(var(--content-gap) * 2);
+  --figure-max-height: calc(
+    calc(100vh - var(--global-ui-height) - var(--figure-ui-size)) *
+      var(--video-aspect-ratio)
+  );
+  --intrinsic-width: calc(var(--figure-ui-size) + var(--video-width));
+  --figure-width: min(var(--intrinsic-width), var(--figure-max-height));
+
+  display: flex;
+  justify-content: center;
+  width: 100%;
+`;

--- a/components/layout/WidgetContainer/styles.ts
+++ b/components/layout/WidgetContainer/styles.ts
@@ -4,16 +4,9 @@ import styled from "styled-components";
 export const WidgetBlock = styled.div`
   --target-height: 1;
   --widget-header-height: 36px;
-  --widget-padding-resize: 0.5;
-  --widget-padding: calc(
-    var(--PADDING_SMALL, 20px) * var(--widget-padding-resize)
-  );
+  --widget-padding: var(--content-gap);
   --widget-header-padding: calc(var(--PADDING_SMALL, 20px) / 4);
   --instructions-height: 2em;
-
-  --global-ui-height: calc(
-    var(--pager-height, 0px) + var(--header-height, 0px)
-  );
   --widget-ui-height: calc(
     var(--widget-header-height, 0px) + var(--widget-padding, 0px)
   );
@@ -38,7 +31,6 @@ export const WidgetBlock = styled.div`
   height: 100%;
 
   @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
-    --widget-padding-resize: 1;
     --target-height: 0.85;
 
     background-color: transparent;

--- a/components/page/Body/styles.ts
+++ b/components/page/Body/styles.ts
@@ -6,11 +6,18 @@ export const Body = styled.body`
   --header-height: 80px;
   --pager-height: 40px;
   --scrollbar-width: calc(100vw - 100%);
+  --global-ui-height: calc(
+    var(--pager-height, 0px) + var(--header-height, 0px)
+  );
+  --content-gap: calc(var(--PADDING_SMALL, 20px) / 2);
 
   overflow-y: scroll;
 
   @media screen and (min-width: ${token("BREAK_TABLET_MIN")}) {
     --pager-height: 80px;
+  }
+  @media screen and (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    --content-gap: var(--PADDING_SMALL, 20px);
   }
   @media screen and (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
     --pager-height: 70px;

--- a/helpers/assets.ts
+++ b/helpers/assets.ts
@@ -1,15 +1,68 @@
+import { RawImage } from "@/types/image";
+import { getAssetMetadata } from ".";
+
 type ValidCantoSize = 100 | 240 | 320 | 500 | 640 | 800 | 2050;
 
 const ValidCantoSizes: Array<ValidCantoSize> = [
   100, 240, 320, 500, 640, 800, 2050,
 ];
 
-export const resizeCantoImage = (previewUrl: string, size: ValidCantoSize) => {
-  if (ValidCantoSizes.includes(size)) {
+export const isValidCantoSize = (size: any): size is ValidCantoSize => {
+  return ValidCantoSizes.includes(size);
+};
+
+export const resizeCantoImage = (previewUrl: string, size: number) => {
+  if (isValidCantoSize(size)) {
     const urlWithoutConstraint = previewUrl.slice(0, -3);
 
     return urlWithoutConstraint.concat(size.toString());
   }
 
   return previewUrl;
+};
+
+const responsiveCantoSrc = (
+  previewUrl: string,
+  originalUrl: string,
+  width: number
+) => {
+  const eligibleSizes = ValidCantoSizes.filter((size) => size < width);
+  const srcset = eligibleSizes.map(
+    (size) => `${resizeCantoImage(previewUrl, size)} ${size}w`
+  );
+
+  srcset.push(`${originalUrl} ${width}w`);
+
+  const sizes = eligibleSizes.map((size) => {
+    return `(max-width: ${size}px): ${size}px`;
+  }, "");
+
+  sizes.push(`${width}px`);
+
+  return {
+    srcSet: srcset.join(", "),
+    sizes: sizes.join(", "),
+  };
+};
+
+export const damAssetToImage = (site = "default", data: RawImage) => {
+  if (!data) return undefined;
+
+  const { metadata, url, width, height } = data;
+  const { directUrlPreview, directUrlOriginal } = url;
+  const { altText: alt, ...assetMetadata } =
+    getAssetMetadata(metadata, site) || {};
+
+  return {
+    src: directUrlPreview,
+    ...responsiveCantoSrc(
+      directUrlPreview,
+      directUrlOriginal,
+      parseFloat(width)
+    ),
+    width: parseFloat(width),
+    height: parseFloat(height),
+    alt,
+    ...assetMetadata,
+  };
 };

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -75,7 +75,7 @@ const localeKeys = {
   es: "ES",
 };
 
-const getAssetMetadata = (
+export const getAssetMetadata = (
   metadata: Record<string, string>,
   site = "default"
 ): { altText?: string; caption?: string; credit?: string } | undefined => {
@@ -133,8 +133,8 @@ export const videoShaper = (
   return {
     url: directUrlPreviewPlay,
     thumbnail: directUrlPreview,
-    width: Number(width),
-    height: Number(height),
+    width: parseFloat(width),
+    height: parseFloat(height),
     ...getAssetMetadata(metadata, site),
   };
 };

--- a/theme/styles/base/_base.scss
+++ b/theme/styles/base/_base.scss
@@ -47,15 +47,6 @@ img {
   display: block;
   width: 100%;
   height: auto;
-
-  // &[loading] {
-  //   opacity: 0;
-  //   transition: opacity 0.4s 0.1s;
-
-  //   &.is-loaded {
-  //     opacity: 1;
-  //   }
-  // }
 }
 
 a {

--- a/types/video.d.ts
+++ b/types/video.d.ts
@@ -12,8 +12,8 @@ export interface Video {
   altText?: string;
   caption?: string;
   credit?: string;
-  width?: number;
-  height?: number;
+  width: number;
+  height: number;
   url: string;
   thumbnail?: string;
 }


### PR DESCRIPTION
## What this change does ##

Limits the size of images and videos. Each block picks the smaller of two sizes: the natural width/height of the content or the available height of the window between the top nav and the pager. 

Canto image re-sizing has also been re-written to include a better `srcset` and `sizes` so browsers can select a better (and hopefully smaller) image when available.

Resolves #200 
