### PR TITLE
[B] store calculator values as strings

### DIFF
--- a/components/calculators/Interactive/index.tsx
+++ b/components/calculators/Interactive/index.tsx
@@ -24,10 +24,9 @@ const InteractiveCalculator: FunctionComponent<InteractiveCalculatorProps> = ({
     onChangeCallback &&
       onChangeCallback({
         ...value,
-        [key]: parseFloat((event.target as HTMLInputElement).value),
+        [key]: (event.target as HTMLInputElement).value,
       });
   };
-
   return (
     <Styled.MathContainer>
       <Styled.Inputs id={id}>

--- a/components/calculators/Static/index.tsx
+++ b/components/calculators/Static/index.tsx
@@ -1,12 +1,12 @@
 import { FunctionComponent } from "react";
-import { CalculatorValues, Equation } from "@/types/calculators";
+import { StoredCalculatorValues, Equation } from "@/types/calculators";
 import Calculator from "@/components/calculators/lib";
 import EquationRenderer from "@/components/atomic/Equation";
 import { fallbackLng } from "@/lib/i18n/settings";
 
 const StaticCalculator: FunctionComponent<{
   equation: Equation;
-  value: CalculatorValues;
+  value: StoredCalculatorValues;
   locale?: string;
 }> = ({ equation, value, locale = fallbackLng }) => {
   const { latex } = Calculator(equation, value, locale);

--- a/components/calculators/interactive/index.tsx
+++ b/components/calculators/interactive/index.tsx
@@ -24,10 +24,9 @@ const InteractiveCalculator: FunctionComponent<InteractiveCalculatorProps> = ({
     onChangeCallback &&
       onChangeCallback({
         ...value,
-        [key]: parseFloat((event.target as HTMLInputElement).value),
+        [key]: (event.target as HTMLInputElement).value,
       });
   };
-
   return (
     <Styled.MathContainer>
       <Styled.Inputs id={id}>

--- a/components/calculators/lib/index.ts
+++ b/components/calculators/lib/index.ts
@@ -1,25 +1,41 @@
 import { fallbackLng } from "@/lib/i18n/settings";
+import isNil from "lodash/isNil";
 import {
-  Calculator,
-  CalculatorValues,
-  NonNullableCalculatorValues,
+  type Calculator,
+  StoredCalculatorValues,
+  NumericCalculatorValues,
 } from "@/types/calculators";
 import Equations from "./equations";
 import LaTeXComposer from "./latex";
 import Config from "./config";
 
-const cleanInput = (values: CalculatorValues): NonNullableCalculatorValues => {
-  const nonNullValues: NonNullableCalculatorValues = {};
+const storedToNumericValues = (
+  values: StoredCalculatorValues
+): NumericCalculatorValues => {
+  const numericValues: NumericCalculatorValues = {};
 
   Object.keys(values).forEach((key) => {
-    nonNullValues[key] = values[key] ?? undefined;
+    const value = values[key];
+    numericValues[key] = isNil(value) ? undefined : parseFloat(value);
+
+    if (isNil(value)) {
+      numericValues[key] = undefined;
+      return;
+    }
+
+    if (value === "") {
+      numericValues[key] = undefined;
+      return;
+    }
+
+    numericValues[key] = parseFloat(value);
   });
 
-  return nonNullValues;
+  return numericValues;
 };
 
 const Calculator: Calculator = (equation, value, locale = fallbackLng) => {
-  const variables = cleanInput(value);
+  const variables = storedToNumericValues(value);
   const config = Config[equation];
 
   if (typeof config === "undefined") {

--- a/components/calculators/lib/latex.ts
+++ b/components/calculators/lib/latex.ts
@@ -20,7 +20,7 @@ const formatVariable = ({
   config: { precision, sigFigs, placeholder },
   locale = fallbackLng,
 }: {
-  variable?: number;
+  variable?: number | string;
   config: Variable;
   locale?: string;
 }) => {
@@ -59,7 +59,10 @@ const formatResult = ({
 
 const LaTeXComposer = (
   equation: EquationConfig,
-  values: { result?: number; variables: Record<string, number | undefined> },
+  values: {
+    result?: number;
+    variables: Record<string, string | number | undefined>;
+  },
   locale = fallbackLng
 ) => {
   const { latex, constants, inputs, result: resultConfig } = equation;

--- a/components/calculators/static/index.tsx
+++ b/components/calculators/static/index.tsx
@@ -1,12 +1,12 @@
 import { FunctionComponent } from "react";
-import { CalculatorValues, Equation } from "@/types/calculators";
+import { StoredCalculatorValues, Equation } from "@/types/calculators";
 import Calculator from "@/components/calculators/lib";
 import EquationRenderer from "@/components/atomic/Equation";
 import { fallbackLng } from "@/lib/i18n/settings";
 
 const StaticCalculator: FunctionComponent<{
   equation: Equation;
-  value: CalculatorValues;
+  value: StoredCalculatorValues;
   locale?: string;
 }> = ({ equation, value, locale = fallbackLng }) => {
   const { latex } = Calculator(equation, value, locale);

--- a/types/calculators.d.ts
+++ b/types/calculators.d.ts
@@ -1,6 +1,6 @@
 export type Equation = "peakAbsoluteMagnitude" | "distanceModulus";
-export type CalculatorValues = Record<string, number | null | undefined>;
-export type NonNullableCalculatorValues = Record<string, number | undefined>;
+export type StoredCalculatorValues = Record<string, string | null | undefined>;
+export type NumericCalculatorValues = Record<string, number | undefined>;
 
 export interface Variable {
   key: string;
@@ -31,7 +31,7 @@ export interface EquationConfig {
   result: Result;
 }
 
-export type Calculator<T = CalculatorValues> = (
+export type Calculator<T = StoredCalculatorValues> = (
   equation: Equation,
   variables: T,
   locale?: string
@@ -41,7 +41,7 @@ export type Calculator<T = CalculatorValues> = (
   latex: string;
 };
 
-export interface InteractiveCalculatorProps<T = CalculatorValues> {
+export interface InteractiveCalculatorProps<T = StoredCalculatorValues> {
   id: string;
   equation: Equation;
   onChangeCallback: (value: Partial<T>) => void;
@@ -50,6 +50,6 @@ export interface InteractiveCalculatorProps<T = CalculatorValues> {
 }
 
 export type EquationComposer = (
-  values: NonNullableCalculatorValues,
+  values: Record<string, number | undefined>,
   constants: Record<string, Constant>
 ) => number | undefined;

--- a/types/calculators.d.ts
+++ b/types/calculators.d.ts
@@ -50,6 +50,6 @@ export interface InteractiveCalculatorProps<T = StoredCalculatorValues> {
 }
 
 export type EquationComposer = (
-  values: Record<string, number | undefined>,
+  values: NumericCalculatorValues,
   constants: Record<string, Constant>
 ) => number | undefined;


### PR DESCRIPTION
Resolves #209 

## What this change does ##

Store all calculator values as strings to preserve trailing zeroes. Values are then parsed into numbers before they go into the equation evaluator itself. 
