### PR TITLE
fix: dropdowns behind questions

### DIFF
--- a/components/calculators/Interactive/styles.ts
+++ b/components/calculators/Interactive/styles.ts
@@ -1,4 +1,5 @@
 "use client";
+import { token } from "@rubin-epo/epo-react-lib/styles";
 import styled from "styled-components";
 
 export const MathContainer = styled.div`
@@ -10,6 +11,14 @@ export const MathContainer = styled.div`
   gap: var(--math-gap);
   justify-items: left;
   min-width: 50%;
+
+  @container (min-width: ${token("BREAK_MOBILE_MIN")}) {
+    font-size: 125%;
+  }
+
+  @container (min-width: ${token("BREAK_TABLET_MIN")}) {
+    font-size: 150%;
+  }
 `;
 
 export const Inputs = styled.form`

--- a/components/calculators/interactive/styles.ts
+++ b/components/calculators/interactive/styles.ts
@@ -1,4 +1,5 @@
 "use client";
+import { token } from "@rubin-epo/epo-react-lib/styles";
 import styled from "styled-components";
 
 export const MathContainer = styled.div`
@@ -10,6 +11,14 @@ export const MathContainer = styled.div`
   gap: var(--math-gap);
   justify-items: left;
   min-width: 50%;
+
+  @container (min-width: ${token("BREAK_MOBILE_MIN")}) {
+    font-size: 125%;
+  }
+
+  @container (min-width: ${token("BREAK_TABLET_MIN")}) {
+    font-size: 150%;
+  }
 `;
 
 export const Inputs = styled.form`

--- a/components/content-blocks/Questions/styles.ts
+++ b/components/content-blocks/Questions/styles.ts
@@ -13,7 +13,6 @@ export const QuestionList = styled.ol`
 
   background-color: var(--list-background-color, transparent);
   color: var(--question-color);
-  isolation: isolate;
   list-style-type: decimal;
   list-style-position: inside;
   padding: var(--list-padding, 0);

--- a/components/questions/Calculator/index.tsx
+++ b/components/questions/Calculator/index.tsx
@@ -5,7 +5,6 @@ import useAnswer from "@/hooks/useAnswer";
 import { isNullish } from "@/lib/utils";
 import { WidgetInput } from "@/types/answers";
 import InteractiveCalculator from "@/components/calculators/Interactive";
-import QuestionNumber from "../QuestionNumber";
 import * as Styled from "./styles";
 import { Equation } from "@/types/calculators";
 
@@ -32,7 +31,7 @@ const CalculatorQuestion: FunctionComponent<CalculatorQuestionProps> = ({
   if (isNullish(equation)) return null;
 
   return (
-    <QuestionNumber {...{ id }}>
+    <Styled.QuestionNumber {...{ id }}>
       <label htmlFor={id}>{questionText}</label>
       <Styled.CalculatorWrapper>
         <InteractiveCalculator
@@ -44,7 +43,7 @@ const CalculatorQuestion: FunctionComponent<CalculatorQuestionProps> = ({
           }}
         />
       </Styled.CalculatorWrapper>
-    </QuestionNumber>
+    </Styled.QuestionNumber>
   );
 };
 

--- a/components/questions/Calculator/index.tsx
+++ b/components/questions/Calculator/index.tsx
@@ -5,6 +5,7 @@ import useAnswer from "@/hooks/useAnswer";
 import { isNullish } from "@/lib/utils";
 import { WidgetInput } from "@/types/answers";
 import InteractiveCalculator from "@/components/calculators/Interactive";
+import QuestionNumber from "../QuestionNumber";
 import * as Styled from "./styles";
 import { Equation } from "@/types/calculators";
 
@@ -31,7 +32,7 @@ const CalculatorQuestion: FunctionComponent<CalculatorQuestionProps> = ({
   if (isNullish(equation)) return null;
 
   return (
-    <Styled.QuestionNumber {...{ id }}>
+    <QuestionNumber {...{ id }}>
       <label htmlFor={id}>{questionText}</label>
       <Styled.CalculatorWrapper>
         <InteractiveCalculator
@@ -43,7 +44,7 @@ const CalculatorQuestion: FunctionComponent<CalculatorQuestionProps> = ({
           }}
         />
       </Styled.CalculatorWrapper>
-    </Styled.QuestionNumber>
+    </QuestionNumber>
   );
 };
 

--- a/components/questions/Calculator/styles.ts
+++ b/components/questions/Calculator/styles.ts
@@ -1,6 +1,7 @@
 "use client";
 import styled from "styled-components";
 import { token } from "@rubin-epo/epo-react-lib/styles";
+import BaseQuestionNumber from "../QuestionNumber";
 
 export const CalculatorWrapper = styled.div`
   display: flex;
@@ -15,4 +16,8 @@ export const CalculatorWrapper = styled.div`
   @container (min-width: ${token("BREAK_TABLET_MIN")}) {
     font-size: 150%;
   }
+`;
+
+export const QuestionNumber = styled(BaseQuestionNumber)`
+  container-type: inline-size;
 `;

--- a/components/questions/Calculator/styles.ts
+++ b/components/questions/Calculator/styles.ts
@@ -1,23 +1,10 @@
 "use client";
 import styled from "styled-components";
-import { token } from "@rubin-epo/epo-react-lib/styles";
-import BaseQuestionNumber from "../QuestionNumber";
 
 export const CalculatorWrapper = styled.div`
   display: flex;
   justify-content: center;
   font-size: 100%;
   color: var(--neutral95, #1f2121);
-
-  @container (min-width: ${token("BREAK_MOBILE_MIN")}) {
-    font-size: 125%;
-  }
-
-  @container (min-width: ${token("BREAK_TABLET_MIN")}) {
-    font-size: 150%;
-  }
-`;
-
-export const QuestionNumber = styled(BaseQuestionNumber)`
   container-type: inline-size;
 `;

--- a/components/questions/QuestionNumber/index.tsx
+++ b/components/questions/QuestionNumber/index.tsx
@@ -15,7 +15,6 @@ const QuestionNumber: FunctionComponent<
 > = ({ id, direction = "block", className, children }) => {
   const questions = useQuestions();
 
-  const maxIndex = questions.byAll.length - 1;
   const questionIndex = questions.byAll.findIndex(
     (question) => question.id === id
   );
@@ -25,7 +24,6 @@ const QuestionNumber: FunctionComponent<
       value={questionIndex + 1}
       data-direction={direction}
       className={className}
-      style={{ "--z-index-dropdown-open": maxIndex - questionIndex }}
     >
       {children}
     </Styled.Number>

--- a/components/questions/QuestionNumber/index.tsx
+++ b/components/questions/QuestionNumber/index.tsx
@@ -25,7 +25,7 @@ const QuestionNumber: FunctionComponent<
       value={questionIndex + 1}
       data-direction={direction}
       className={className}
-      style={{ zIndex: maxIndex - questionIndex }}
+      style={{ "--z-index-dropdown-open": maxIndex - questionIndex }}
     >
       {children}
     </Styled.Number>

--- a/components/questions/QuestionNumber/styles.ts
+++ b/components/questions/QuestionNumber/styles.ts
@@ -2,9 +2,6 @@
 import styled from "styled-components";
 
 export const Number = styled.li`
-  container-type: inline-size;
-  position: relative;
-
   &[data-direction="block"] {
     & > * + * {
       margin-block-start: var(--PADDING_SMALL, 20px);


### PR DESCRIPTION
## What this change does ##

Resolves #214 

Remove the `container-type: inline-size` that interferes with z-indexing on dropdown questions and replace with a customized instance of `QuestionNumber` where it is needed as a container for Equations.
