### PR TITLE
[B] inline select width auto

### DIFF
--- a/components/questions/MultipartQuestion/Select/index.tsx
+++ b/components/questions/MultipartQuestion/Select/index.tsx
@@ -38,6 +38,7 @@ const Select: FunctionComponent<PartProps<FragmentType<typeof Fragment>>> = ({
       onChangeCallback={(value: string | null) =>
         onChangeCallback && onChangeCallback({ ...answer, [id]: value })
       }
+      maxWidth="auto"
       value={answer ? answer[id] : null}
     />
   );


### PR DESCRIPTION
Resolves #202 

## What this change does ##

Sets width of inline select dropdowns to `auto` so they do not overflow other elements