### PR TITLE
fix: parse answers before saving

### DIFF
--- a/components/educator-schema/saveAnswersAction.ts
+++ b/components/educator-schema/saveAnswersAction.ts
@@ -35,10 +35,11 @@ export default async function saveAnswers(
     return "statusError";
   }
 
-  const answerSet = Object.values(answers).map(({ data, ...values }) => {
+  const answerSet = Object.values(answers).map(({ data, id, questionId }) => {
     return {
       data: JSON.stringify(data),
-      ...values,
+      id,
+      questionId,
     };
   });
 

--- a/components/student-schema/saveAnswersAction.ts
+++ b/components/student-schema/saveAnswersAction.ts
@@ -35,10 +35,11 @@ export default async function saveAnswers(
     return "statusError";
   }
 
-  const answerSet = Object.values(answers).map(({ data, ...values }) => {
+  const answerSet = Object.values(answers).map(({ data, id, questionId }) => {
     return {
       data: JSON.stringify(data),
-      ...values,
+      id,
+      questionId,
     };
   });
 


### PR DESCRIPTION
## What this change does ##

Parse answers before saving so that only `data`, `questionId` and `id` are attached to the `Answer` object that is sent up to the server

Resolves #244 
