### PR TITLE
fix: multiselect receive empty array instead of null

### DIFF
--- a/components/questions/MultipartQuestion/Multiselect/index.tsx
+++ b/components/questions/MultipartQuestion/Multiselect/index.tsx
@@ -25,18 +25,19 @@ const Multiselect: FunctionComponent<
   PartProps<FragmentType<typeof Fragment>>
 > = ({ id, questionId, data }) => {
   const { options } = useFragment(Fragment, data);
-  const { answer, onChangeCallback } =
+  const { answer = {}, onChangeCallback } =
     useAnswer<MultipartQuestionData>(questionId);
   const { t } = useTranslation();
+  const value = answer[id] || [];
 
   return (
     <Styled.InlineSelect
-      {...{ options }}
+      {...{ options, value }}
       placeholder={t("translation:placeholder.select")}
       onChangeCallback={(value: string[] | null) =>
         onChangeCallback && onChangeCallback({ ...answer, [id]: value })
       }
-      value={answer ? answer[id] : []}
+      maxWidth="auto"
       isMultiselect
     />
   );


### PR DESCRIPTION
## What this change does ##

It was possible for multiselects to receive `null` instead of an empty array which would cause an error to be thrown when opening the list dropdown. Add destructuring fallbacks to make sure an empty array is the default value passed.

Resolves #249 