### PR TITLE
K8s updates

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -88,7 +88,7 @@ jobs:
             type=gha
           build-args: |
             BASE_TAG=k8s
-            BUILD=false
+            RUN_BUILD=false
       - name: Summary
         run: |
           cat <<-EOT >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -88,6 +88,7 @@ jobs:
             type=gha
           build-args: |
             BASE_TAG=k8s
+            BUILD=false
       - name: Summary
         run: |
           cat <<-EOT >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,12 @@ ARG CRAFT_SECRET_TOKEN
 ARG CRAFT_EDUCATOR_SCHEMA_SECRET_TOKEN
 ARG CRAFT_STUDENT_SCHEMA_SECRET_TOKEN
 
-RUN npx browserslist@latest --update-db && yarn static:build
+RUN npx browserslist@latest --update-db
+
+ARG RUN_BUILD="true"
+ENV RUN_BUILD=${RUN_BUILD}
+
+RUN if $RUN_BUILD;then yarn static:build;fi
 
 # Production image, copy all the files and run next
 FROM node:20-alpine AS runner


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/<ID>

## What this change does ##

- Updated the int environment branch from `master` to `main` in the new workflow for k8s deployment
- Updated the Dockerfile to make the site build its own optional step. It still runs by default but can be disabled by making the build argument `RUN_BUILD` false.

## Notes for reviewers ##

Rubber stamp me!

## Testing ##

Pattern has been tested on the Rubinobs main site

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
