### PR TITLE
fix: add 'force-cache' to query

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,8 +1,10 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 import { NextRequest } from "next/server";
 import tags from "@/lib/tags";
+import { languages, fallbackLng } from "@/lib/i18n/settings";
 
 const REVALIDATE_SECRET_TOKEN = process.env.CRAFT_SECRET_TOKEN;
+const CRAFT_HOMEPAGE_URI = "__home__";
 
 export async function GET(request: NextRequest) {
   const uri = request.nextUrl.searchParams.get("uri");
@@ -25,7 +27,16 @@ export async function GET(request: NextRequest) {
   }
 
   if (uri) {
-    revalidatePath(`/[locale]/${uri}`, "page");
+    languages.forEach((locale) => {
+      const parts: Array<string> = uri === CRAFT_HOMEPAGE_URI ? [] : [uri];
+      if (locale !== fallbackLng) {
+        parts.unshift(locale);
+      }
+
+      revalidatePath(`/${parts.join("/")}`);
+    });
+
+    revalidateTag(tags.globals);
     Object.entries(tags).forEach(([, tag]) => {
       revalidateTag(tag);
     });

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -30,18 +30,25 @@ export async function queryAPI<
   token?: Token;
   previewToken?: string;
 }): Promise<OperationResult<Query, Variables>> {
-  const url = previewToken ? `${API_URL}?token=${previewToken}` : API_URL;
+  const params = new URLSearchParams({});
+
+  if (previewToken) {
+    params.append("token", previewToken);
+  }
+
   const makeClient = () => {
     return createClient({
-      url,
+      url: `${API_URL}?${params.toString()}`,
       exchanges: [cacheExchange, fetchExchange],
       fetchOptions: () => {
-        const opts = {
+        const opts: RequestInit = {
+          cache: "force-cache",
           next: {
-            revalidate: previewToken ? 0 : 60,
+            revalidate: previewToken ? 0 : undefined,
           },
         };
-        if (!token) return { ...opts };
+
+        if (!token) return opts;
         return {
           ...opts,
           headers: {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
Add the same setup that the rubin-obs-client is using in it's `urql` client to re-enable Next's data caching