### PR TITLE
feat: add SelectionList component to OrbitalSim question widget

### DIFF
--- a/components/content-blocks/OrbitalSim/styles.ts
+++ b/components/content-blocks/OrbitalSim/styles.ts
@@ -4,3 +4,12 @@ export const OrbitalSimWidgetContainer = styled.div`
     min-height: 500px;
     width: 100%;
 `;
+
+export const SelectionListWrapper = styled.div`
+    max-width: 30%;
+    margin-top: var(--PADDING_SMALL);
+    margin-bottom: var(--PADDING_SMALL);
+    button {
+        padding: 0px;
+    }
+`;

--- a/components/questions/Widget/OrbitalSim/index.tsx
+++ b/components/questions/Widget/OrbitalSim/index.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 // to-do: get this working at full width
 // import WidgetContainerWithModal from "@/components/layout/WidgetContainerWithModal";
 import { OrbitalSimProvider, OrbitalSim } from "@rubin-epo/epo-widget-lib/OrbitalSim";
+import SelectionList from "@rubin-epo/epo-widget-lib/atomic/SelectionList/index";
 import Loader from "@/components/page/Loader";
 import * as OrbitalSimStyled from "@/components/content-blocks/OrbitalSim/styles";
 
@@ -40,6 +41,11 @@ const OrbitalSimQuestion: FunctionComponent<
 > = ({ data, instructions, value = {}, onChangeCallback }) => {
   const [dataObj, setDataObj] = useState(null);
   const [url, setUrl] = useState<string>("");
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+
+  function resetSelectedAnswer() {
+    setSelectedAnswer(null);
+  }
 
   /**
    * to-do: this could use a second look, `use()` wasn't working and this
@@ -90,9 +96,12 @@ const OrbitalSimQuestion: FunctionComponent<
         <Loader />
       ) : (
         <OrbitalSimStyled.OrbitalSimWidgetContainer>
-            <OrbitalSimProvider orbitData={ dataObj } showDetailsTable={showDetailsTable} allowOrbitRotation={allowOrbitRotation} showTimeControls={addTimeControls}>
-                <OrbitalSim/>
-            </OrbitalSimProvider>
+          <OrbitalSimStyled.SelectionListWrapper>
+            <SelectionList sources={ selectedAnswer ? [{ type: "observation", id: selectedAnswer}] : [] } onRemoveCallback={ resetSelectedAnswer }/>
+          </OrbitalSimStyled.SelectionListWrapper>
+          <OrbitalSimProvider orbitData={ dataObj } showDetailsTable={showDetailsTable} allowOrbitRotation={allowOrbitRotation} showTimeControls={addTimeControls} selectedAnswer={ selectedAnswer } updateSelectedAnswer={ setSelectedAnswer }>
+            <OrbitalSim/>
+          </OrbitalSimProvider>
         </OrbitalSimStyled.OrbitalSimWidgetContainer>
 
        ) }


### PR DESCRIPTION
## What this change does ##

Resolves #396 

This PR adds the `SelectionList` component to the `OrbitalSim` question widget. The `selectedAnswer` state is declared in the `OrbitalSim` question component and passed into the `OrbitalSimProvider` and `SelectionList`.

## Testing ##

To test this change you'll need to `yarn link` the `epo-widget-lib` on the `ji-handle_set_selected-answer_in_orbitalsim_context_provider` branch instead of using the NPM registry version. Then in Craft you will need to add  a question block to the page with a widget type question (see below). The widget will need to be set to a valid Orbital Sim Block`.

On the page, selecting observations in the Orbital Sim should display your selection on the page and clicking the reset button should clear the selection from the page and with Orbital Sim.

<img width="937" height="831" alt="image" src="https://github.com/user-attachments/assets/d238fda4-02d8-47cd-a434-a1fadbe6cb67" />

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reused styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does