### PR TITLE
refactor: replace local `OrbitalSim` selected answer state management

### DIFF
--- a/components/questions/Widget/OrbitalSim/index.tsx
+++ b/components/questions/Widget/OrbitalSim/index.tsx
@@ -42,10 +42,15 @@ const OrbitalSimQuestion: FunctionComponent<
 > = ({ data, instructions, value = {}, onChangeCallback }) => {
   const [dataObj, setDataObj] = useState(null);
   const [url, setUrl] = useState<string>("");
-  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+
+  const selectedAnswer: string | null = value?.selectedObservation || null;
+
+  function updateAnswer(answer: string | null) {
+    onChangeCallback({ selectedObservation: answer});
+  }
 
   function resetSelectedAnswer() {
-    setSelectedAnswer(null);
+    updateAnswer(null);
   }
 
   /**
@@ -102,7 +107,7 @@ const OrbitalSimQuestion: FunctionComponent<
           <OrbitalSimStyled.SelectionListWrapper>
             <SelectionList sources={ selectedAnswer ? [{ type: "observation", id: selectedAnswer}] : [] } onRemoveCallback={ resetSelectedAnswer }/>
           </OrbitalSimStyled.SelectionListWrapper>
-          <OrbitalSimProvider swappableOrbits={swappableOrbits} orbitData={ dataObj.orbits } showDetailsTable={showDetailsTable} allowOrbitRotation={allowOrbitRotation} showTimeControls={addTimeControls} selectedAnswer={ selectedAnswer } updateSelectedAnswer={ setSelectedAnswer }>
+          <OrbitalSimProvider swappableOrbits={swappableOrbits} orbitData={ dataObj.orbits } showDetailsTable={showDetailsTable} allowOrbitRotation={allowOrbitRotation} showTimeControls={addTimeControls} selectedAnswer={ selectedAnswer } updateSelectedAnswer={ updateAnswer }>
             <OrbitalSim/>
           </OrbitalSimProvider>
         </OrbitalSimStyled.OrbitalSimWidgetContainer>


### PR DESCRIPTION
## What this change does ##

Resolves #406 

Replaces local `OrbitalSim` selected answer state management with the value and change handler provided by the `useAnswer` hook. This keeps the internal selections in sync with the value (or lack of) stored in the users `local storage`.

## Notes for reviewers ##

If [`epo-react-lib` PR 417](https://github.com/lsst-epo/epo-react-lib/pull/417) hasn't been merged yet, the `Observations` will all start as inactive on initial page load due to a bug in the `OrbitalSimProvider`.

## Testing ##

_Assuming the above PR has been merged..._

1. To test this change load the page with no observations selected and observe that the selection is not displayed, the reset button is inactive, and there are no active observations. Local storage should either not have an object populated for this question or it should be set to `{selectedObservation: null }` depending on if you have interacted with this question before.
2. Select an observation and reload the page. The selected observation should be displayed the observation should start in it's active state (blue or green), and the Local Storage question should have an object populated like `{selectedObservation: "A"}`
3. Select a different observation, reload the page. See that the correct observation stays selected.
4. Use the reset button to clear the selection and reload the page. The UI should clear the selections and the Local Storage object should be set to `{selectedObservation: null}`

## Local Storage and UI examples ##
### Selection made:

<img width="1821" height="764" alt="image" src="https://github.com/user-attachments/assets/06114e29-44ef-4339-b6fa-70975512cb85" />

### Selection cleared:

<img width="1821" height="764" alt="image" src="https://github.com/user-attachments/assets/714f4320-83f4-42a0-88b2-b1fde6791a33" />

