### PR TITLE
feat: add a new OrbitalSimReview component for display on the review page

### DIFF
--- a/components/questions/Review/Widget/OrbitalSim/index.tsx
+++ b/components/questions/Review/Widget/OrbitalSim/index.tsx
@@ -1,0 +1,62 @@
+"use client";
+import type { FunctionComponent } from "react";
+import type { WidgetReviewProps } from "..";
+import { useState, useEffect } from "react";
+import {
+  OrbitalSimProvider,
+  OrbitalSim,
+} from "@rubin-epo/epo-widget-lib/OrbitalSim";
+import * as OrbitalSimStyled from "@/components/content-blocks/OrbitalSim/styles";
+
+const OrbitalSimReview: FunctionComponent<WidgetReviewProps> = ({
+  data,
+  value,
+}) => {
+  const [dataObj, setDataObj] = useState(null);
+
+  const url =
+    data.orbitalSimTool[0]?.orbitalDatasets[0]?.orbitalSimData[0]?.json[0]
+      ?.url || "";
+
+  /**
+   * to-do: this could use a second look
+   * Like in the components/questions/Widget/OrbitalSim/index.tsx
+   * component this is what worked but their might be a better way
+   * to get this data than a useEffect.
+   */
+  useEffect(() => {
+    async function getOrbitalData(url: string) {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error("Error fetching the JSON dataset for the Orbital Sim!");
+      }
+      const res = await response.json();
+      setDataObj(res);
+    }
+
+    if (dataObj === null) {
+      getOrbitalData(url);
+    }
+  }, [url, dataObj]);
+
+  /* return <p>Placeholder!</p> */
+
+  return (
+    <OrbitalSimStyled.OrbitalSimWidgetContainer>
+      <OrbitalSimProvider
+        swappableOrbits={false}
+        orbitData={dataObj?.orbits || {}}
+        showDetailsTable={false}
+        allowOrbitRotation={false}
+        showTimeControls={false}
+        selectedAnswer={value.selectedObservation}
+        updateSelectedAnswer={() => null}>
+        <OrbitalSim />
+      </OrbitalSimProvider>
+    </OrbitalSimStyled.OrbitalSimWidgetContainer>
+  );
+};
+
+OrbitalSimReview.displayName = "Review.Widget.OrbitalSim";
+
+export default OrbitalSimReview;

--- a/components/questions/Review/Widget/index.tsx
+++ b/components/questions/Review/Widget/index.tsx
@@ -4,6 +4,7 @@ import ColorFilterToolReview from "./ColorFilterTool";
 import SourceSelectorReview from "./SourceSelector";
 import LightCurveReview from "./LightCurveTool";
 import IsochronePlotReview from "./IsochronePlot";
+import OrbitalSimReview from "./OrbitalSim";
 import { QuestionLabel } from "@/components/questions/Widget/styles";
 import * as Styled from "../styles";
 import { WidgetInput } from "@/types/answers";
@@ -27,6 +28,7 @@ export const WIDGET_MAP: Record<string, ComponentType<WidgetReviewProps>> = {
   questionWidgetsBlock_sourceSelectorBlock_BlockType: SourceSelectorReview,
   questionWidgetsBlock_lightCurveBlock_BlockType: LightCurveReview,
   questionWidgetsBlock_isochronePlot_BlockType: IsochronePlotReview,
+  questionWidgetsBlock_orbitalSimBlock_BlockType: OrbitalSimReview,
 };
 
 const WidgetReviewWrapper: FunctionComponent<WidgetReviewWrapperProps> = ({
@@ -41,7 +43,7 @@ const WidgetReviewWrapper: FunctionComponent<WidgetReviewWrapperProps> = ({
 
   if (!Widget) {
     console.error(
-      `"${__typename}" is not a valid input for this question type.`
+      `"${__typename}" is not a valid input for this question type.`,
     );
 
     return null;


### PR DESCRIPTION
## What this change does ##

Resolves #412 

This PR adds a new `OrbitalSimReview` component and registers it in the `WidgetReviewWrapper` component. This change will add the OrbitalSim to the review page where appropriate, per the question type.

## Notes for reviewers ##

This new component is very similar to the existing `OrbitalSimQuestion` component but diverges in two notable ways.

1. It does not include the `SelectionList` component
2. The props passed into the context provider for things like `showTimeControls` and `allowOrbitRotation` are hardcoded to `false`
3. `updateSelectedAnswer` is passed a no-operation function to keep the types happy and ensure the selected observation cannot be updated on the review page.

Creating a dedicated "review" version of the component and omitting the `SelectionList` component follows the existing patterns so I felt it justified not refactoring the "question" version of the component to accommodate the "review" versions needs.

## Testing ##

To test this change:

1. Make sure you have an OrbitalSim with interactable observations in your investigation.
2. Select and observation in the OrbitalSim
4. Navigate through the rest of the investigation or us the slide out menu to jump to the review page (`Quick Access > Review you answers`)
5. Observe that the OrbitalSim loads with your saved selection marked as the active one active.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does
