### PR TITLE
Er add asteroid size equation

### DIFF
--- a/components/calculators/lib/config.ts
+++ b/components/calculators/lib/config.ts
@@ -18,6 +18,21 @@ export const Variables: Record<string, Variable> = {
     precision: 1,
     placeholder: "M",
   },
+  albedo: {
+    key: "albedo",
+    precision: 2,
+    placeholder: "p"
+  },
+  absoluteMagnitude: {
+    key: "absoluteMagnitude",
+    precision: 2,
+    placeholder: "H"
+  },
+  asteroidSize: {
+    key: "asteroidSize",
+    precision: 0,
+    placeholder: "D"
+  }
 };
 
 const Config: Record<Equation, EquationConfig> = {
@@ -46,6 +61,17 @@ const Config: Record<Equation, EquationConfig> = {
       addUnit: (value) => `${value}\\space\\text{Mly}`,
     },
   },
+  asteroidSize: {
+    latex: ({ result, constants, variables }) =>
+      `${result} = \\frac {${constants.A}}{\\sqrt{${variables.albedo}}}${constants.B}^{${constants.C} \\times ${variables.absoluteMagnitude}}`,
+    constants: {
+      A: { value: 1329000 },
+      B: { value: 10 },
+      C: { value: -0.2 }
+    },
+    inputs: [Variables.albedo, Variables.absoluteMagnitude],
+    result: Variables.asteroidSize
+  }
 };
 
 export default Config;

--- a/components/calculators/lib/equations.ts
+++ b/components/calculators/lib/equations.ts
@@ -29,9 +29,25 @@ const distanceModulus: EquationComposer = (
   return undefined;
 };
 
+const asteroidSize: EquationComposer = (
+  { albedo, absoluteMagnitude },
+  { A, B, C}
+) => {
+  if(isNumber(albedo) && isNumber(absoluteMagnitude)) {
+    const dividend = A.value / Math.sqrt(albedo);
+    const exponent = Math.pow(B.value, (C.value * absoluteMagnitude));
+    const unroundedResult = dividend * exponent;
+    const result = Math.round((unroundedResult/10)) * 10;
+    return result;
+  }
+  return undefined;
+
+}
+
 const Equations: Record<Equation, EquationComposer> = {
   peakAbsoluteMagnitude,
   distanceModulus,
+  asteroidSize
 };
 
 export default Equations;

--- a/types/calculators.d.ts
+++ b/types/calculators.d.ts
@@ -1,4 +1,4 @@
-export type Equation = "peakAbsoluteMagnitude" | "distanceModulus";
+export type Equation = "peakAbsoluteMagnitude" | "distanceModulus" | "asteroidSize";
 export type StoredCalculatorValues = Record<string, string | null | undefined>;
 export type NumericCalculatorValues = Record<string, number | undefined>;
 


### PR DESCRIPTION
Adds a new equation to the client and its corresponding formula. This is reliant on a Craft project config update already in the `develop` branch of `investigations-api`.

Note the following:
- **components/calculators/lib/config.ts**
  - Where the parameters for the equation and formula are defined, including the LaTeX that live-updates on the page, specifying the inputs automatically creates the input fields in the client
- **components/calculators/lib/equations.ts**
  - Where the actual mathematical calculations and rounding occur
- **types/calculators.d.ts**
  - Where the type for the formula is defined

The actual JSX/formatting occur in the following places:

- **components/calculators/lib/index.ts*
  - What actually builds the calculator widgets
- **components/calculators/Static/index.tsx**
  - For statically rendering the defaults for a formula or values inputted on a previous page
- **components/calculators/Interactive/index.tsx**
  - For interactive (questions) versions of the equation
  