### PR TITLE
fix: revert auto-formatting changes that are breaking the build process

### DIFF
--- a/components/content-blocks/TwoColumnContainer/TwoColumnContainer.tsx
+++ b/components/content-blocks/TwoColumnContainer/TwoColumnContainer.tsx
@@ -62,10 +62,10 @@ export default function TwoColumnContainerBlock(props: {
   if (!columns) return null;
 
   const leftCol = columns.find(
-    (col) => col.__typename === "contentBlocks_colLeft_BlockType",
+    (col) => col.__typename === "contentBlocks_colLeft_BlockType"
   );
   const rightCol = columns.find(
-    (col) => col.__typename === "contentBlocks_colRight_BlockType",
+    (col) => col.__typename === "contentBlocks_colRight_BlockType"
   );
 
   function renderBlocks(blocks) {
@@ -88,7 +88,7 @@ export default function TwoColumnContainerBlock(props: {
   }
 
   return (
-    <Styled.TwoColContainer className='content-block'>
+    <Styled.TwoColContainer className="content-block">
       {leftCol && (
         <Styled.LeftCol>{renderBlocks(leftCol?.childblocks)}</Styled.LeftCol>
       )}


### PR DESCRIPTION
## What this change does ##

Resolves #421 

## Testing ##

Run `yarn static:build` and see that the build process completes.

## Screenshots (optional) ##
### Before:

<img width="1241" height="661" alt="image" src="https://github.com/user-attachments/assets/6126e80a-2e37-4c5f-a6ea-8f4956424623" />ﬁﬁ

### After:

<img width="1241" height="547" alt="image" src="https://github.com/user-attachments/assets/e4e4b294-4fe9-4fc4-8b4e-feba004cc35e" />

<img width="1241" height="685" alt="image" src="https://github.com/user-attachments/assets/165b41d3-2d0b-4340-bbe3-9785f53b5fe2" />
