### PR TITLE
fix: fixed OrbitalSim modal and fullscreen styling

### DIFF
--- a/components/layout/WidgetContainer/styles.ts
+++ b/components/layout/WidgetContainer/styles.ts
@@ -41,6 +41,10 @@ export const WidgetContainer = styled.div`
   max-width: 100%;
   max-height: 100%;
   color: var(--widget-text-color, initial);
+
+  @container (min-width: 800px) {
+    width: 90%;
+  }
 `;
 
 export const WidgetHeader = styled.header`
@@ -69,6 +73,7 @@ export const WidgetBody = styled.div`
 
 export const WidgetRow = styled.div`
   display: flex;
+  justify-content: center;
   flex-direction: column;
   gap: var(--widget-padding);
 

--- a/components/questions/Widget/OrbitalSim/index.tsx
+++ b/components/questions/Widget/OrbitalSim/index.tsx
@@ -3,8 +3,7 @@ import { FunctionComponent, useEffect, useState } from "react";
 import { FragmentType, graphql, useFragment } from "@/gql/public-schema";
 import { WidgetQuestion } from "..";
 import { useTranslation } from "react-i18next";
-// to-do: get this working at full width
-// import WidgetContainerWithModal from "@/components/layout/WidgetContainerWithModal";
+import WidgetContainerWithModal from "@/components/layout/WidgetContainerWithModal";
 import { OrbitalSimProvider, OrbitalSim } from "@rubin-epo/epo-widget-lib/OrbitalSim";
 import SelectionList from "@rubin-epo/epo-widget-lib/atomic/SelectionList/index";
 import Loader from "@/components/page/Loader";
@@ -71,10 +70,6 @@ const OrbitalSimQuestion: FunctionComponent<
     }
   }, [url, dataObj]);
 
-  /**
-   * to-do: uncomment this when the <WidgetContainerWithModal> styling
-   *        has been added so we can translate the title
-   */
   const { t } = useTranslation();
   const { orbitalSimTool } = useFragment(Fragment, data);
   const addTimeControls = orbitalSimTool[0]?.addTimeControls;
@@ -90,16 +85,12 @@ const OrbitalSimQuestion: FunctionComponent<
     setUrl(orbitalSimTool[0]?.orbitalDatasets[0]?.orbitalSimData[0]?.json[0]?.url);
   }
 
-  /**
-   * to-do: Figure out the <WidgetContainerWithModal> styling
-   */
-
   return (
     <>
-    {/* <WidgetContainerWithModal
+    <WidgetContainerWithModal
       title={t("widgets.orbital_sim.title")}
       instructions={instructions}
-    > */}
+    >
       {dataObj === null ? (
         <Loader />
       ) : (
@@ -113,7 +104,7 @@ const OrbitalSimQuestion: FunctionComponent<
         </OrbitalSimStyled.OrbitalSimWidgetContainer>
 
        ) }
-    {/* </WidgetContainerWithModal> */}
+    </WidgetContainerWithModal>
     </>
   );
 };

--- a/components/questions/Widget/OrbitalSim/styles.ts
+++ b/components/questions/Widget/OrbitalSim/styles.ts
@@ -1,6 +1,0 @@
-import styled from "styled-components";
-import WidgetContainerWithModal from "@/components/layout/WidgetContainerWithModal";
-
-export const WidgetContainer = styled(WidgetContainerWithModal)`
-    width: 100% !important;
-`;


### PR DESCRIPTION
Resolves #408 

## What this change does ##

The `flex-direction:column` and `align-items: center` rules on `WidgetBlock` was overriding the `width:100%` rule coming from the `WidgetContainer` that wrapped OrbitalSim. This change makes some styling adjustments to allow the OrbitalSim to take up more width and to go properly fullscreen. Additionally, some centering for other widgets on smaller dimensions was added.

## Testing ##

1. In your Investigations Craft instance, add a Question Block to any page in an investigation with an OrbitalSim widget entry. 
2. Additionally, add other entries of other widget types for comparison.
3. In the client, navigate to the page with the widget question entries. 
4. Ensure the `OrbitalSim` and other widgets take up a majority of the width of the page and are not taking a narrow width.
5. Click the fullscreen button on each widget and confirm the dimensions of the widgets increase to fill the screen dimensions without altering their aspect ratios drastically enough to affect the widget contents.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
<img width="1412" height="908" alt="image" src="https://github.com/user-attachments/assets/f3edd78e-7d92-4cb0-b97a-5ba722f2448a" />
<img width="1726" height="1084" alt="image" src="https://github.com/user-attachments/assets/3d83890a-3ca8-4f17-94fc-d288110bda11" />

### After:
<img width="1463" height="931" alt="image" src="https://github.com/user-attachments/assets/8d16a8e3-3675-4921-bbbf-2b1da174b9d3" />
<img width="1726" height="1073" alt="image" src="https://github.com/user-attachments/assets/fc74d784-aeae-4bad-9df0-2c0eaabadfcf" />
