### PR TITLE
fix: the MovingSourceSelector image and selected source being out of sync on the review page

### DIFF
--- a/components/questions/Review/Widget/SourceSelector/index.tsx
+++ b/components/questions/Review/Widget/SourceSelector/index.tsx
@@ -36,7 +36,8 @@ const SourceSelectorReview: FunctionComponent<
     <>
       {hasMovingSource ? (
         <MovingSourceSelector
-          {...{ alerts, selectedSource, isLoading }}
+          alerts={alertData}
+          {...{ selectedSource, isLoading }}
           movingSources={percentageMappedSources}
           width={size}
           height={size}


### PR DESCRIPTION
## What this change does ##

Resolves #424 

This corrects the logic determining what alert data gets passed into the `MovingSourceSelector` on the review page. Currently the `MovingSourceSelector` needs the raw, unprocessed `alerts` data to function correctly. Passing in the alerts processed by the `combineAlertsAndImagesForMovingSources` helper function returns an array where every alert is mapped to the first image in the Canto album.

_Passing in the raw alerts in the `review` instance of the component matches the pattern in the `question` instance. I accidentally diverged from this when I implemented my previous fix._

## Testing ##

This fix can be confirmed by viewing the component on the review page.


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
<img width="897" height="657" alt="image" src="https://github.com/user-attachments/assets/4833af94-1bbd-4eb1-b34a-6c741d6aaaf2" />

### After:
<img width="897" height="657" alt="image" src="https://github.com/user-attachments/assets/e7134785-9c28-404f-96b5-1d0ca372cd75" />
