### PR TITLE
fix: fixed `z-index` of header, bumped dep ver

### DIFF
--- a/components/page/Header/styles.ts
+++ b/components/page/Header/styles.ts
@@ -13,7 +13,7 @@ export const Header = styled.header`
   background-color: var(--turquoise85, #12726d);
   transform: none;
   transition: transform 0.4s;
-  z-index: 1000;
+  z-index: 15;
 
   &[aria-hidden="true"] {
     transform: translate3d(0, -100%, 0);

--- a/helpers/widgets.ts
+++ b/helpers/widgets.ts
@@ -81,7 +81,7 @@ export const percentageMapSources = <T extends { x: any; y: any; radius: any }>(
 /**
  * todo: refine this function
  */
-export const percentageMapSourcesForMovingSources = <T extends { x: any; y: any; radius: any }>(
+export const percentageMapSourcesForMovingSources = <T extends { x: any; y: any; radius: any, type: string }>(
   sources: Array<T>
 ) => {
   let updatedSources = {};

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@react-input/number-format": "^2.0.3",
     "@react-oauth/google": "^0.11.0",
     "@rubin-epo/epo-react-lib": "3.0.2",
-    "@rubin-epo/epo-widget-lib": "2.0.10",
+    "@rubin-epo/epo-widget-lib": "2.0.11",
     "@unly/universal-language-detector": "^2.0.3",
     "@urql/core": "^5.0.6",
     "@urql/exchange-auth": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3312,10 +3312,10 @@
     styled-components "^6.1.16"
     utopia-core "^1.6.0"
 
-"@rubin-epo/epo-widget-lib@2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-widget-lib/-/epo-widget-lib-2.0.10.tgz#6eb9462cc727686ce162b234e86ee15f0a93283f"
-  integrity sha512-iFM8wGCr+fc1wcX28qcO1J3R6JbtDaQaOBK3B+jdQ3XEZh28OL5K1XQ9YsUScz6U7QQLGRJWLiiF0GKyGpCL1g==
+"@rubin-epo/epo-widget-lib@2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-widget-lib/-/epo-widget-lib-2.0.11.tgz#331dfe5473d059cf792f50a0027db81460737f66"
+  integrity sha512-obAVfP/O+/DuIJe1tSI7KdVkYg/tt7Jd1IwxSTgvRxICN9JQt+O4558iDTj+A6kiwbA5Xk8VwxCbe7zQphMSeA==
   dependencies:
     "@react-three/drei" "^10.7.6"
     "@react-three/fiber" "9"


### PR DESCRIPTION
- Fixed the z-index issue that was causing the `OrbitalSim` object details table to display over the header nav. 
- Bumped the `@rubin-epo/epo-widget-lib` dependency version to `2.0.11`