### PR TITLE
fix: improve width styles for the `OrbitalSim` `SelectionList` components in the two-column layouts

### DIFF
--- a/components/content-blocks/OrbitalSim/styles.ts
+++ b/components/content-blocks/OrbitalSim/styles.ts
@@ -6,10 +6,14 @@ export const OrbitalSimWidgetContainer = styled.div`
 `;
 
 export const SelectionListWrapper = styled.div`
-    max-width: 30%;
+    max-width: 40%;
     margin-top: var(--PADDING_SMALL);
     margin-bottom: var(--PADDING_SMALL);
     button {
         padding: 0px;
+    }
+
+    @container (width < 800px) {
+        max-width: 100%;
     }
 `;

--- a/components/layout/WidgetContainer/styles.ts
+++ b/components/layout/WidgetContainer/styles.ts
@@ -45,6 +45,10 @@ export const WidgetContainer = styled.div`
   @container (min-width: 800px) {
     width: 90%;
   }
+
+  @container (width < 800px) {
+    width: 100%;
+  }
 `;
 
 export const WidgetHeader = styled.header`

--- a/components/questions/Widget/OrbitalSim/index.tsx
+++ b/components/questions/Widget/OrbitalSim/index.tsx
@@ -95,12 +95,12 @@ const OrbitalSimQuestion: FunctionComponent<
         <Loader />
       ) : (
         <OrbitalSimStyled.OrbitalSimWidgetContainer>
-          <OrbitalSimStyled.SelectionListWrapper>
-            <SelectionList sources={ selectedAnswer ? [{ type: "observation", id: selectedAnswer}] : [] } onRemoveCallback={ resetSelectedAnswer }/>
-          </OrbitalSimStyled.SelectionListWrapper>
           <OrbitalSimProvider swappableOrbits={swappableOrbits} orbitData={ dataObj.orbits } showDetailsTable={showDetailsTable} allowOrbitRotation={allowOrbitRotation} showTimeControls={addTimeControls} selectedAnswer={ selectedAnswer } updateSelectedAnswer={ updateAnswer }>
             <OrbitalSim/>
           </OrbitalSimProvider>
+          <OrbitalSimStyled.SelectionListWrapper>
+            <SelectionList sources={ selectedAnswer ? [{ type: "observation", id: selectedAnswer}] : [] } onRemoveCallback={ resetSelectedAnswer }/>
+          </OrbitalSimStyled.SelectionListWrapper>
         </OrbitalSimStyled.OrbitalSimWidgetContainer>
 
        ) }


### PR DESCRIPTION
## What this change does ##

Resolves #426 

This PR updates the `max-width` CSS property for the `SelectionListWrapper` to display in a better way in the two-column layouts. It also fixes a bug where the flexbox rules were causing the `WidgetContainer` to become very narrow when the parent container was smaller than 800px. (We did not anticipate the widget being used in the two-column layout when issue #408 was addressed.)

It also moves the selection list below the `OrbitalSim` to match the pattern of other widgets across the investigations. This has been discussed in Slack and was Jose's recommendation.

## Testing ##

To test this change, add an `OrbitalSim` question block with selectable observations to a two-column layout container.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
<img width="768" height="1178" alt="image" src="https://github.com/user-attachments/assets/57d8dec3-f034-4745-89e9-d744c0165f0a" />

### After:
<img width="768" height="1244" alt="image" src="https://github.com/user-attachments/assets/84a06a0a-0566-4eea-bb59-40cd4003b794" />
