### PR TITLE
fix: filter static layout typenames

### DIFF
--- a/app/[locale]/[investigation]/[page]/layout.tsx
+++ b/app/[locale]/[investigation]/[page]/layout.tsx
@@ -62,16 +62,26 @@ export const generateStaticParams = async ({
     },
   });
 
-  return data?.entry?.children?.map((entry) => {
+  return data?.entry?.children?.filter(entry => {
     if (
       entry?.__typename === "investigations_default_Entry" ||
       entry?.__typename ===
         "investigations_investigationSectionBreakChild_Entry"
     ) {
-      const { slug } = entry;
-
-      return { page: slug };
+      return entry;
+    } else {
+      console.info("Found unexpected `__typename` on entry: ", JSON.stringify(entry));
     }
+  }).map((entry) => {
+    // Typescript loses context of what type "entry" is at this point
+    // so instead of doing messy forced typing, just check if key is
+    // on object
+    if(!("slug" in entry)) {
+      console.info("Found investigations entry without slug: ", JSON.stringify(entry));
+        return [];
+    }
+    const { slug } = entry;
+    return { page: slug };
   });
 };
 


### PR DESCRIPTION
We are statically rendering the investigations pages at build time, but also only allowing for two specific `__typename` values in `generateStaticParams` to do so. Previously, this was being done with `.map()` alone. There was a conditional block that checked if the `__typename` was one of the two acceptable values and when it wasn't `undefined` is being returned because `.map()` will always return the exact same amount of elements as the source array. The Next.js build was breaking because it expects everything returned from `generateStaticParams` to contain the `page` property with a value which of course is not true in the case of `undefined`.

The fix for now is to `filter()` the elements by `__typename` prior to calling `.map()` so what gets fed into `.map()` already contains the entry type that will have a `page`.

I find the `__typename` check dubious in the first place, but to immediately fix the issue and, with some logging, to troubleshoot the problematic entry this will be the initial fix.

Once the problematic entry is identified we can reverse engineer what's in the Craft pages hierarchy and determine if we need to make this section of the code more flexible, or if the pages hierarchy needs to be updated.