### PR TITLE
fix: add missing WidgetContainerWithModal to non-question OrbitalSim component sans title

### DIFF
--- a/components/content-blocks/OrbitalSim/OrbitalSimWidget.tsx
+++ b/components/content-blocks/OrbitalSim/OrbitalSimWidget.tsx
@@ -4,6 +4,7 @@ import type { WidgetInput } from "@/types/answers";
 
 import { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import WidgetContainerWithModal from "@/components/layout/WidgetContainerWithModal";
 import {
   OrbitalSimProvider,
   OrbitalSim,
@@ -115,45 +116,47 @@ const OrbitalSimWidget: FunctionComponent<
    * to-do: flesh out styling for `OrbitalSimWidgetContainer`
    */
   return (
-    <Styled.OrbitalSimWidgetContainer>
-      {!dataObj ? (
-        <Loader />
-      ) : (
-        <>
-          <OrbitalSimProvider
-            swappableOrbits={swappableOrbits}
-            orbitData={dataObj.orbits}
-            defaultZoom={defaultZoom ?? 0.5}
-            showDetailsTable={showDetailsTable}
-            allowOrbitRotation={allowOrbitRotation}
-            showTimeControls={addTimeControls}
-            selectedNeoIndex={
-              showDetailsTable ? assignedNeoIndex ?? 0 : undefined
-            }>
-            <OrbitalSim />
-          </OrbitalSimProvider>
-          {showDetailsTable && isEducator && (
-            <>
-              <p>{t("widgets.orbital_sim.instructor_neo_override_tip")}</p>
-              <SelectListbox
-                value={assignedNeoIndex}
-                options={dataObj?.orbits?.neos?.map((neo, i) => ({
-                  value: i,
-                  label: neo.Principal_desig,
-                }))}
-                onChangeCallback={(newIndex) =>
-                  setNeoIndex({
-                    ...value,
-                    assignedNeoIndex: newIndex,
-                    dataType: "content",
-                  })
-                }
-              />
-            </>
-          )}
-        </>
-      )}
-    </Styled.OrbitalSimWidgetContainer>
+    <WidgetContainerWithModal>
+      <Styled.OrbitalSimWidgetContainer>
+        {!dataObj ? (
+          <Loader />
+        ) : (
+          <>
+            <OrbitalSimProvider
+              swappableOrbits={swappableOrbits}
+              orbitData={dataObj.orbits}
+              defaultZoom={defaultZoom ?? 0.5}
+              showDetailsTable={showDetailsTable}
+              allowOrbitRotation={allowOrbitRotation}
+              showTimeControls={addTimeControls}
+              selectedNeoIndex={
+                showDetailsTable ? assignedNeoIndex ?? 0 : undefined
+              }>
+              <OrbitalSim />
+            </OrbitalSimProvider>
+            {showDetailsTable && isEducator && (
+              <>
+                <p>{t("widgets.orbital_sim.instructor_neo_override_tip")}</p>
+                <SelectListbox
+                  value={assignedNeoIndex}
+                  options={dataObj?.orbits?.neos?.map((neo, i) => ({
+                    value: i,
+                    label: neo.Principal_desig,
+                  }))}
+                  onChangeCallback={(newIndex) =>
+                    setNeoIndex({
+                      ...value,
+                      assignedNeoIndex: newIndex,
+                      dataType: "content",
+                    })
+                  }
+                />
+              </>
+            )}
+          </>
+        )}
+      </Styled.OrbitalSimWidgetContainer>
+    </WidgetContainerWithModal>
   );
 };
 

--- a/components/questions/Widget/OrbitalSim/index.tsx
+++ b/components/questions/Widget/OrbitalSim/index.tsx
@@ -95,35 +95,36 @@ const OrbitalSimQuestion: FunctionComponent<
   return (
     <>
       <WidgetContainerWithModal
-        title={t("widgets.orbital_sim.title")}
         instructions={instructions}>
-        {!dataObj ? (
-          <Loader />
-        ) : (
-          <OrbitalSimStyled.OrbitalSimWidgetContainer>
-            <OrbitalSimProvider
-              swappableOrbits={swappableOrbits}
-              orbitData={dataObj.orbits}
-              defaultZoom={defaultZoom ?? 0.5}
-              showDetailsTable={showDetailsTable}
-              allowOrbitRotation={allowOrbitRotation}
-              showTimeControls={addTimeControls}
-              selectedAnswer={selectedAnswer}
-              updateSelectedAnswer={updateAnswer}>
-              <OrbitalSim />
-            </OrbitalSimProvider>
-            <OrbitalSimStyled.SelectionListWrapper>
-              <SelectionList
-                sources={
-                  selectedAnswer
-                    ? [{ type: "observation", id: selectedAnswer }]
-                    : []
-                }
-                onRemoveCallback={resetSelectedAnswer}
-              />
-            </OrbitalSimStyled.SelectionListWrapper>
-          </OrbitalSimStyled.OrbitalSimWidgetContainer>
-        )}
+        <OrbitalSimStyled.OrbitalSimWidgetContainer>
+          {!dataObj ? (
+            <Loader />
+          ) : (
+            <>
+              <OrbitalSimProvider
+                swappableOrbits={swappableOrbits}
+                orbitData={dataObj.orbits}
+                defaultZoom={defaultZoom ?? 0.5}
+                showDetailsTable={showDetailsTable}
+                allowOrbitRotation={allowOrbitRotation}
+                showTimeControls={addTimeControls}
+                selectedAnswer={selectedAnswer}
+                updateSelectedAnswer={updateAnswer}>
+                <OrbitalSim />
+              </OrbitalSimProvider>
+              <OrbitalSimStyled.SelectionListWrapper>
+                <SelectionList
+                  sources={
+                    selectedAnswer
+                      ? [{ type: "observation", id: selectedAnswer }]
+                      : []
+                  }
+                  onRemoveCallback={resetSelectedAnswer}
+                />
+              </OrbitalSimStyled.SelectionListWrapper>
+            </>
+          )}
+        </OrbitalSimStyled.OrbitalSimWidgetContainer>
       </WidgetContainerWithModal>
     </>
   );

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@react-input/number-format": "^2.0.3",
     "@react-oauth/google": "^0.11.0",
     "@rubin-epo/epo-react-lib": "3.0.3",
-    "@rubin-epo/epo-widget-lib": "2.2.0",
+    "@rubin-epo/epo-widget-lib": "2.2.1",
     "@unly/universal-language-detector": "^2.0.3",
     "@urql/core": "^5.0.6",
     "@urql/exchange-auth": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,14 +3295,31 @@
     styled-components "^6.1.16"
     utopia-core "^1.6.0"
 
-"@rubin-epo/epo-widget-lib@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-widget-lib/-/epo-widget-lib-2.2.0.tgz#fef53836bf9c28d92c7bccfa7f0142b0802cf926"
-  integrity sha512-sw+jPda23q5aq98uhYymPYpnggk65TqMz6RITpygDU/jzNF0c04nbt+RR9KORDhNpOotfPMDFZ1HKAEuoDAbFg==
+"@rubin-epo/epo-react-lib@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-3.0.4.tgz#65281789a0b4b311b167b46e4313285b723456d1"
+  integrity sha512-UCSRAUo3JJeQbQp1IxFE876GQEJ07alrrBuCj1MbuYplN3SwG69XdF19LwW/uC6C1i/x26byJNuAi4kndQyEgA==
+  dependencies:
+    "@castiron/style-mixins" "^1.0.6"
+    "@headlessui/react" "^2.2.0"
+    flickity "^3.0.0"
+    focus-trap "^7.4.2"
+    lodash "^4.17.21"
+    react-icons "^5.5.0"
+    react-player "^2.14.1"
+    react-share "^5.2.2"
+    react-slider "^2.0.6"
+    styled-components "^6.1.16"
+    utopia-core "^1.6.0"
+
+"@rubin-epo/epo-widget-lib@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-widget-lib/-/epo-widget-lib-2.2.1.tgz#0a723af5b4b3fee7deaa74bb9a7ab33821526648"
+  integrity sha512-fsLLn+MOMQ9ZuAxz/gyuEb8x8qyHVj7PJS6Am3PvuXOzkTn5V5PuyCkxURiurv9KzDY8GoSYy8h/IyO5Z3SF5g==
   dependencies:
     "@react-three/drei" "^10.7.6"
     "@react-three/fiber" "9"
-    "@rubin-epo/epo-react-lib" "3.0.3"
+    "@rubin-epo/epo-react-lib" "^3.0.4"
     context-filter-polyfill "^0.3.6"
     d3-array "^3.2.4"
     d3-geo "^3.1.1"


### PR DESCRIPTION
## What this change does ##
Resolves #446

This PR adds the missing WidgetContainerWithModal to non-question OrbitalSim component sans title. It also fixed the question component so that the `loader` is contained in the `WidgetContainerWithModal` and removed the `title` from all `OrbitalSim` implementations, as requested.

## Testing ##

This change can be tested by viewing any of the non-question `OrbitalSim` widgets.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
<img width="640" height="805" alt="image" src="https://github.com/user-attachments/assets/988db43c-cc2e-4f05-9cb8-c3fccbe03d08" />


### After:
<img width="640" height="853" alt="image" src="https://github.com/user-attachments/assets/f8a8cca2-cf4a-483b-b729-db71f61724c7" />
