### PR TITLE
Ji 453 fix haz ast moving source selector pulling images from netlify

### DIFF
--- a/components/questions/Review/Widget/SourceSelector/index.tsx
+++ b/components/questions/Review/Widget/SourceSelector/index.tsx
@@ -36,7 +36,7 @@ const SourceSelectorReview: FunctionComponent<
     <>
       {hasMovingSource ? (
         <MovingSourceSelector
-          alerts={alertData}
+          alerts={alerts}
           {...{ selectedSource, isLoading }}
           movingSources={percentageMappedSources}
           width={size}

--- a/components/questions/Widget/SourceSelector/index.tsx
+++ b/components/questions/Widget/SourceSelector/index.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState } from "react";
 import { FragmentType, graphql, useFragment } from "@/gql/public-schema";
 import SourceSelector, {
   SelectionList,
-  MovingSourceSelector
+  MovingSourceSelector,
 } from "@rubin-epo/epo-widget-lib/SourceSelector";
 import useAlerts from "@/lib/api/hooks/useAlerts";
 import WidgetContainerWithModal from "@/components/layout/WidgetContainerWithModal";
@@ -12,7 +12,7 @@ import {
   combineAlertsAndImages,
   percentageMapSources,
   percentageMapSourcesForMovingSources,
-  combineAlertsAndImagesForMovingSources
+  combineAlertsAndImagesForMovingSources,
 } from "@/helpers/widgets";
 
 const Fragment = graphql(`
@@ -102,18 +102,23 @@ const SourceSelectorQuestion: FunctionComponent<
       });
   };
 
-  const percentageMappedSources = hasMovingSource ? percentageMapSourcesForMovingSources(sources) : percentageMapSources(sources);
+  const percentageMappedSources = hasMovingSource
+    ? percentageMapSourcesForMovingSources(sources)
+    : percentageMapSources(sources);
+
   const selectedSources: Array<{ type: string; id: string }> = sources
     .filter(({ id }) => selectedSource.includes(id))
     .map(({ id, type }) => {
       return { id, type };
-    }).filter((obj, index, self) => index === self.findIndex((t) => t.id === obj.id));
+    })
+    .filter(
+      (obj, index, self) => index === self.findIndex((t) => t.id === obj.id),
+    );
 
-  const { alerts: alertsWithImages, size } = hasMovingSource ? combineAlertsAndImagesForMovingSources(alerts,
-                                                                imageAlbum || []) : combineAlertsAndImages(
-                                                                alerts,
-                                                                imageAlbum || []
-  );
+  const { alerts: alertsWithImages, size } = hasMovingSource
+  ? combineAlertsAndImagesForMovingSources(alerts, imageAlbum || [])
+  : combineAlertsAndImages(alerts, imageAlbum || []);
+
   return (
     <>
       <WidgetContainerWithModal
@@ -124,43 +129,43 @@ const SourceSelectorQuestion: FunctionComponent<
             onRemoveCallback={handleRemoveSource}
           />
         }
-        {...{ instructions }}
-      >
+        {...{ instructions }}>
         <>
-        {hasMovingSource ? (
-          <MovingSourceSelector
-            alerts={alerts}
-            selectionCallback={(data) =>
-              onChangeCallback && onChangeCallback({ selectedSource: data })
-            }
-            alertChangeCallback={setActiveAlertIndex}
-            width={size}
-            height={size}
-            movingSources={percentageMappedSources}
-            {...{ selectedSource, activeAlertIndex, isLoading }}
-          >
-
-          </MovingSourceSelector>
-        ) : (
-          <>
-          <SourceSelector
-            alerts={alertsWithImages}
-            selectionCallback={(data) =>
-              onChangeCallback && onChangeCallback({ selectedSource: data })
-            }
-            alertChangeCallback={setActiveAlertIndex}
-            width={size}
-            height={size}
-            sources={percentageMappedSources}
-            {...{ selectedSource, activeAlertIndex, isLoading }}
-          />
-          {!!includeScatterPlot && (
-            <MagnitudeScatterPlotContainer
-              showPlot={selectedSource.length > 0}
-              {...{ alerts, peakMjd, yMin, yMax, activeAlertIndex }}
-            />
-          )}
-          </>
+          {hasMovingSource ? (
+            <MovingSourceSelector
+              alerts={alertsWithImages}
+              selectionCallback={(data) =>
+                onChangeCallback && onChangeCallback({ selectedSource: data })
+              }
+              alertChangeCallback={setActiveAlertIndex}
+              width={size}
+              height={size}
+              movingSources={percentageMappedSources}
+              {...{
+                selectedSource,
+                activeAlertIndex,
+                isLoading,
+              }}></MovingSourceSelector>
+          ) : (
+            <>
+              <SourceSelector
+                alerts={alertsWithImages}
+                selectionCallback={(data) =>
+                  onChangeCallback && onChangeCallback({ selectedSource: data })
+                }
+                alertChangeCallback={setActiveAlertIndex}
+                width={size}
+                height={size}
+                sources={percentageMappedSources}
+                {...{ selectedSource, activeAlertIndex, isLoading }}
+              />
+              {!!includeScatterPlot && (
+                <MagnitudeScatterPlotContainer
+                  showPlot={selectedSource.length > 0}
+                  {...{ alerts, peakMjd, yMin, yMax, activeAlertIndex }}
+                />
+              )}
+            </>
           )}
         </>
       </WidgetContainerWithModal>


### PR DESCRIPTION
## What this change does ##
Resolves #453 

This PR fixes the bug where the the MovingSourceSelector widget, used on the 3rd page of the Hazardous Asteroids investigation, was still using the images hosted on Netlify instead of the Canto album that was set in Craft. This was happening because we were passing the `alerts` array, which is parsed from the Alerts Dataset file, directly into the `alerts` prop of the `MovingSourceSelector` component instead of the processed `alertsWithImages` array that has alerts and images paired up.

This was also required in the "review" implementation of the widget.

## Notes ##

**The data set loaded in Craft will need to be updated as part of deploying this fix.**

## Testing ##

To test this fix, replicate the widget setup for the `hazardous-asteroids/detecting-an-asteroid` page in your local investigations-api Craft instance. However, for the Alerts Data set create and upload a .json file with the following data.

_Note: Some of the data points are not directly needed for the widget to work, but they might still be needed by other parties if this data needs to be updated or reviewed later so I am opting to leave it as is._

```
{
    "id": "",
    "name": "hazardous-asteroids",
    "band": "r",
    "dec": 18.74361216,
    "ra": 45.08449499,
    "distance": 141.69708547161875,
    "velocity": 9736.736057325023,
    "redshift": 0.033,
    "sources": null,
    "movingSources": [],
    "alerts": [
        {
            "id": "2003_QZ30_0",
            "error": 0.05,
            "date": 58719.46459,
            "magnitude": 17.58
        },
        {
            "id": "2003_QZ30_1",
            "error": 0.04,
            "date": 58722.4869,
            "magnitude": 17.35
        },
        {
            "id": "2003_QZ30_2",
            "error": 0.03,
            "date": 58725.49949,
            "magnitude": 17.24
        }
    ]
}
```

Verify the following are true:

- [x] selection circle moves with the asteroid
- [x] label is shown correctly
- [x] review page shows the widget correctly
- [x] Dev Tools Network tab confirms that images are not fetched from Netlify 

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does
